### PR TITLE
Fix issues with wrong reference declaration in project file

### DIFF
--- a/devices/AD5328/AD5328.nfproj
+++ b/devices/AD5328/AD5328.nfproj
@@ -20,8 +20,8 @@
   </PropertyGroup>
   <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.props" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.props')" />
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.4.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>packages\nanoFramework.CoreLibrary.1.10.4-preview.11\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.10.5.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>packages\nanoFramework.CoreLibrary.1.10.5-preview.18\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/devices/AD5328/packages.config
+++ b/devices/AD5328/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.4-preview.11" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.10.5-preview.18" targetFramework="netnanoframework10" />
   <package id="nanoFramework.Runtime.Events" version="1.9.0-preview.26" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Device.Gpio" version="1.0.0-preview.40" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Device.Spi" version="1.0.0-preview.38" targetFramework="netnanoframework10" />

--- a/devices/Ads1115/Ads1115.nfproj
+++ b/devices/Ads1115/Ads1115.nfproj
@@ -19,8 +19,8 @@
   </PropertyGroup>
   <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.props" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.props')" />
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.4.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>packages\nanoFramework.CoreLibrary.1.10.4-preview.11\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.10.5.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>packages\nanoFramework.CoreLibrary.1.10.5-preview.18\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/devices/Ads1115/packages.config
+++ b/devices/Ads1115/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.4-preview.11" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.10.5-preview.18" targetFramework="netnanoframework10" />
   <package id="nanoFramework.Runtime.Events" version="1.9.0-preview.26" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Device.Gpio" version="1.0.0-preview.40" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Device.I2c" version="1.0.1-preview.33" targetFramework="netnanoframework10" />

--- a/devices/Adxl345/Adxl345.nfproj
+++ b/devices/Adxl345/Adxl345.nfproj
@@ -27,8 +27,8 @@
   </PropertyGroup>
   <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.props" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.props')" />
   <ItemGroup>
-    <Reference Include="mscorlib">
-      <HintPath>packages\nanoFramework.CoreLibrary.1.10.4-preview.11\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.10.5.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>packages\nanoFramework.CoreLibrary.1.10.5-preview.18\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Device.Spi">
@@ -50,6 +50,23 @@
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
     <None Include="*.md" />
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="mscorlib, Version=1.10.5.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>packages\nanoFramework.CoreLibrary.1.10.5-preview.18\lib\mscorlib.dll</HintPath>
+      <Private>True</Private>
+      <SpecificVersion>True</SpecificVersion>
+    </Reference>
+    <Reference Include="System.Device.Spi, Version=1.0.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>packages\nanoFramework.System.Device.Spi.1.0.0-preview.70\lib\System.Device.Spi.dll</HintPath>
+      <Private>True</Private>
+      <SpecificVersion>True</SpecificVersion>
+    </Reference>
+    <Reference Include="System.Math, Version=1.4.1.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>packages\nanoFramework.System.Math.1.4.1-preview.7\lib\System.Math.dll</HintPath>
+      <Private>True</Private>
+      <SpecificVersion>True</SpecificVersion>
+    </Reference>
   </ItemGroup>
   <Import Project="..\..\src\BinaryPrimitives\BinaryPrimitives.projitems" Label="Shared" />
   <Import Project="..\..\src\System.Device.Model\System.Device.Model.projitems" Label="Shared" />

--- a/devices/Adxl345/packages.config
+++ b/devices/Adxl345/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.4-preview.11" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.System.Device.Spi" version="1.0.0-preview.38" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.System.Math" version="1.4.0-preview.7" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.10.5-preview.18" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.System.Device.Spi" version="1.0.0-preview.70" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.System.Math" version="1.4.1-preview.7" targetFramework="netnanoframework10" />
   <package id="Nerdbank.GitVersioning" version="3.4.194" developmentDependency="true" targetFramework="netnanoframework10" />
 </packages>

--- a/devices/Adxl357/Adxl357.nfproj
+++ b/devices/Adxl357/Adxl357.nfproj
@@ -20,8 +20,8 @@
   </PropertyGroup>
   <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.props" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.props')" />
   <ItemGroup>
-    <Reference Include="mscorlib">
-      <HintPath>packages\nanoFramework.CoreLibrary.1.10.4-preview.11\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.10.5.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>packages\nanoFramework.CoreLibrary.1.10.5-preview.18\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Device.Gpio">
@@ -33,7 +33,7 @@
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>
-    <Reference Include="System.Device.I2c">
+    <Reference Include="System.Device.I2c, Version=1.0.1.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>packages\nanoFramework.System.Device.I2c.1.0.1-preview.33\lib\System.Device.I2c.dll</HintPath>
       <Private>True</Private>
     </Reference>

--- a/devices/Adxl357/packages.config
+++ b/devices/Adxl357/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.4-preview.11" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.10.5-preview.18" targetFramework="netnanoframework10" />
   <package id="nanoFramework.Runtime.Events" version="1.9.0-preview.26" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Device.Gpio" version="1.0.0-preview.40" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Device.I2c" version="1.0.1-preview.33" targetFramework="netnanoframework10" />

--- a/devices/Ags01db/Ags01db.nfproj
+++ b/devices/Ags01db/Ags01db.nfproj
@@ -20,15 +20,15 @@
   </PropertyGroup>
   <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.props" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.props')" />
   <ItemGroup>
-    <Reference Include="mscorlib">
-      <HintPath>packages\nanoFramework.CoreLibrary.1.10.4-preview.11\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.10.5.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>packages\nanoFramework.CoreLibrary.1.10.5-preview.18\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Device.Gpio">
       <HintPath>packages\nanoFramework.System.Device.Gpio.1.0.0-preview.40\lib\System.Device.Gpio.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Device.I2c">
+    <Reference Include="System.Device.I2c, Version=1.0.1.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>packages\nanoFramework.System.Device.I2c.1.0.1-preview.33\lib\System.Device.I2c.dll</HintPath>
       <Private>True</Private>
     </Reference>

--- a/devices/Ags01db/packages.config
+++ b/devices/Ags01db/packages.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.4-preview.11" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.10.5-preview.18" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Device.Gpio" version="1.0.0-preview.40" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Device.I2c" version="1.0.1-preview.33" targetFramework="netnanoframework10" />
   <package id="UnitsNet.nanoFramework.Length" version="4.91.0" targetFramework="netnanoframework10" />

--- a/devices/Ahtxx/Ahtxx.nfproj
+++ b/devices/Ahtxx/Ahtxx.nfproj
@@ -19,8 +19,8 @@
   </PropertyGroup>
   <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.props" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.props')" />
   <ItemGroup>
-    <Reference Include="mscorlib">
-      <HintPath>packages\nanoFramework.CoreLibrary.1.10.4-preview.11\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.10.5.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>packages\nanoFramework.CoreLibrary.1.10.5-preview.18\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nanoFramework.Runtime.Events, Version=1.9.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
@@ -32,7 +32,7 @@
       <HintPath>packages\nanoFramework.System.Device.Gpio.1.0.0-preview.40\lib\System.Device.Gpio.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Device.I2c">
+    <Reference Include="System.Device.I2c, Version=1.0.1.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>packages\nanoFramework.System.Device.I2c.1.0.1-preview.33\lib\System.Device.I2c.dll</HintPath>
       <Private>True</Private>
     </Reference>

--- a/devices/Ahtxx/packages.config
+++ b/devices/Ahtxx/packages.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.4-preview.11" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.10.5-preview.18" targetFramework="netnanoframework10" />
   <package id="nanoFramework.Runtime.Events" version="1.9.0-preview.26" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Device.Gpio" version="1.0.0-preview.40" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Device.I2c" version="1.0.1-preview.33" targetFramework="netnanoframework10" />

--- a/devices/Ak8963/Ak8963.nfproj
+++ b/devices/Ak8963/Ak8963.nfproj
@@ -21,8 +21,8 @@
   </PropertyGroup>
   <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.props" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.props')" />
   <ItemGroup>
-    <Reference Include="mscorlib">
-      <HintPath>packages\nanoFramework.CoreLibrary.1.10.4-preview.11\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.10.5.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>packages\nanoFramework.CoreLibrary.1.10.5-preview.18\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nanoFramework.Runtime.Events, Version=1.9.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">

--- a/devices/Ak8963/packages.config
+++ b/devices/Ak8963/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.4-preview.11" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.10.5-preview.18" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Device.I2c" version="1.0.1-preview.33" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Math" version="1.4.0-preview.7" targetFramework="netnanoframework10" />
   <package id="Nerdbank.GitVersioning" version="3.4.194" developmentDependency="true" targetFramework="netnanoframework10" />

--- a/devices/Amg88xx/Amg88xx.nfproj
+++ b/devices/Amg88xx/Amg88xx.nfproj
@@ -19,8 +19,8 @@
   </PropertyGroup>
   <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.props" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.props')" />
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.4.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>packages\nanoFramework.CoreLibrary.1.10.4-preview.11\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.10.5.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>packages\nanoFramework.CoreLibrary.1.10.5-preview.18\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/devices/Amg88xx/packages.config
+++ b/devices/Amg88xx/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.4-preview.11" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.10.5-preview.18" targetFramework="netnanoframework10" />
   <package id="nanoFramework.Runtime.Events" version="1.9.0-preview.26" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Device.Gpio" version="1.0.0-preview.40" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Device.I2c" version="1.0.1-preview.33" targetFramework="netnanoframework10" />

--- a/devices/Apa102/Apa102.nfproj
+++ b/devices/Apa102/Apa102.nfproj
@@ -19,8 +19,8 @@
   </PropertyGroup>
   <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.props" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.props')" />
   <ItemGroup>
-    <Reference Include="mscorlib">
-      <HintPath>packages\nanoFramework.CoreLibrary.1.10.4-preview.11\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.10.5.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>packages\nanoFramework.CoreLibrary.1.10.5-preview.18\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Device.Gpio">

--- a/devices/Apa102/packages.config
+++ b/devices/Apa102/packages.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.4-preview.11" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.10.5-preview.18" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Device.Gpio" version="1.0.0-preview.40" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Device.Spi" version="1.0.0-preview.38" targetFramework="netnanoframework10" />
   <package id="UnitsNet.nanoFramework.Length" version="4.91.0" targetFramework="netnanoframework10" />

--- a/devices/Bh1745/Bh1745.nfproj
+++ b/devices/Bh1745/Bh1745.nfproj
@@ -19,15 +19,15 @@
   </PropertyGroup>
   <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.props" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.props')" />
   <ItemGroup>
-    <Reference Include="mscorlib">
-      <HintPath>packages\nanoFramework.CoreLibrary.1.10.4-preview.11\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.10.5.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>packages\nanoFramework.CoreLibrary.1.10.5-preview.18\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Device.Gpio">
       <HintPath>packages\nanoFramework.System.Device.Gpio.1.0.0-preview.40\lib\System.Device.Gpio.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Device.I2c">
+    <Reference Include="System.Device.I2c, Version=1.0.1.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>packages\nanoFramework.System.Device.I2c.1.0.1-preview.33\lib\System.Device.I2c.dll</HintPath>
       <Private>True</Private>
     </Reference>

--- a/devices/Bh1745/packages.config
+++ b/devices/Bh1745/packages.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.4-preview.11" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.10.5-preview.18" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Device.Gpio" version="1.0.0-preview.40" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Device.I2c" version="1.0.1-preview.33" targetFramework="netnanoframework10" />
   <package id="UnitsNet.nanoFramework.Length" version="4.91.0" targetFramework="netnanoframework10" />

--- a/devices/Bh1745/samples/Basic/packages.config
+++ b/devices/Bh1745/samples/Basic/packages.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.4-preview.11" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.10.5-preview.18" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Device.Gpio" version="1.0.0-preview.40" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Device.I2c" version="1.0.1-preview.33" targetFramework="netnanoframework10" />
 </packages>

--- a/devices/Bh1745/samples/Bh1745CustomConfiguration.Sample.csproj
+++ b/devices/Bh1745/samples/Bh1745CustomConfiguration.Sample.csproj
@@ -21,7 +21,7 @@
   <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.props" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.props')" />
   <ItemGroup>
     <Reference Include="mscorlib">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.4-preview.11\lib\mscorlib.dll</HintPath>
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5-preview.18\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Device.Gpio">

--- a/devices/Bh1750fvi/Bh1750fvi.nfproj
+++ b/devices/Bh1750fvi/Bh1750fvi.nfproj
@@ -20,11 +20,11 @@
   </PropertyGroup>
   <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.props" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.props')" />
   <ItemGroup>
-    <Reference Include="mscorlib">
-      <HintPath>packages\nanoFramework.CoreLibrary.1.10.4-preview.11\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.10.5.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>packages\nanoFramework.CoreLibrary.1.10.5-preview.18\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Device.I2c">
+    <Reference Include="System.Device.I2c, Version=1.0.1.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>packages\nanoFramework.System.Device.I2c.1.0.1-preview.33\lib\System.Device.I2c.dll</HintPath>
       <Private>True</Private>
     </Reference>

--- a/devices/Bh1750fvi/packages.config
+++ b/devices/Bh1750fvi/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.4-preview.11" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.10.5-preview.18" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Device.I2c" version="1.0.1-preview.33" targetFramework="netnanoframework10" />
   <package id="Nerdbank.GitVersioning" version="3.4.194" developmentDependency="true" targetFramework="netnanoframework10" />
   <package id="UnitsNet.nanoFramework.Illuminance" version="4.92.1" targetFramework="netnanoframework10" />

--- a/devices/Bmp180/Bmp180.nfproj
+++ b/devices/Bmp180/Bmp180.nfproj
@@ -20,11 +20,11 @@
   </PropertyGroup>
   <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.props" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.props')" />
   <ItemGroup>
-    <Reference Include="mscorlib">
-      <HintPath>packages\nanoFramework.CoreLibrary.1.10.4-preview.11\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.10.5.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>packages\nanoFramework.CoreLibrary.1.10.5-preview.18\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Device.I2c">
+    <Reference Include="System.Device.I2c, Version=1.0.1.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>packages\nanoFramework.System.Device.I2c.1.0.1-preview.33\lib\System.Device.I2c.dll</HintPath>
       <Private>True</Private>
     </Reference>

--- a/devices/Bmp180/packages.config
+++ b/devices/Bmp180/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.4-preview.11" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.10.5-preview.18" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Device.I2c" version="1.0.1-preview.33" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Math" version="1.4.0-preview.7" targetFramework="netnanoframework10" />
   <package id="Nerdbank.GitVersioning" version="3.4.194" developmentDependency="true" targetFramework="netnanoframework10" />

--- a/devices/Bmxx80/Bmxx80.nfproj
+++ b/devices/Bmxx80/Bmxx80.nfproj
@@ -21,11 +21,11 @@
   </PropertyGroup>
   <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.props" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.props')" />
   <ItemGroup>
-    <Reference Include="mscorlib">
-      <HintPath>packages\nanoFramework.CoreLibrary.1.10.4-preview.11\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.10.5.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>packages\nanoFramework.CoreLibrary.1.10.5-preview.18\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Device.I2c">
+    <Reference Include="System.Device.I2c, Version=1.0.1.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>packages\nanoFramework.System.Device.I2c.1.0.1-preview.33\lib\System.Device.I2c.dll</HintPath>
       <Private>True</Private>
     </Reference>

--- a/devices/Bmxx80/packages.config
+++ b/devices/Bmxx80/packages.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.4-preview.11" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.10.5-preview.18" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Device.I2c" version="1.0.1-preview.33" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Math" version="1.4.0-preview.9" targetFramework="netnanoframework10" />
   <package id="UnitsNet.nanoFramework.Duration" version="4.92.1" targetFramework="netnanoframework10" />

--- a/devices/Bno055/Bno055.nfproj
+++ b/devices/Bno055/Bno055.nfproj
@@ -41,33 +41,33 @@
     <None Include="README.md" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.4.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>packages\nanoFramework.CoreLibrary.1.10.4-preview.11\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.10.5.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>packages\nanoFramework.CoreLibrary.1.10.5-preview.18\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>
-    <Reference Include="nanoFramework.Runtime.Events, Version=1.9.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>packages\nanoFramework.Runtime.Events.1.9.0-preview.26\lib\nanoFramework.Runtime.Events.dll</HintPath>
+    <Reference Include="nanoFramework.Runtime.Events, Version=1.9.1.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>packages\nanoFramework.Runtime.Events.1.9.1-preview.7\lib\nanoFramework.Runtime.Events.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>
     <Reference Include="System.Device.Gpio, Version=1.0.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>packages\nanoFramework.System.Device.Gpio.1.0.0-preview.40\lib\System.Device.Gpio.dll</HintPath>
+      <HintPath>packages\nanoFramework.System.Device.Gpio.1.0.0-preview.48\lib\System.Device.Gpio.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>
     <Reference Include="System.Device.I2c, Version=1.0.1.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>packages\nanoFramework.System.Device.I2c.1.0.1-preview.33\lib\System.Device.I2c.dll</HintPath>
+      <HintPath>packages\nanoFramework.System.Device.I2c.1.0.1-preview.38\lib\System.Device.I2c.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>
-    <Reference Include="System.Math, Version=1.4.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>packages\nanoFramework.System.Math.1.4.0-preview.7\lib\System.Math.dll</HintPath>
+    <Reference Include="System.Math, Version=1.4.1.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>packages\nanoFramework.System.Math.1.4.1-preview.7\lib\System.Math.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>
     <Reference Include="UnitsNet.Temperature, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>packages\UnitsNet.nanoFramework.Temperature.4.91.0\lib\UnitsNet.Temperature.dll</HintPath>
+      <HintPath>packages\UnitsNet.nanoFramework.Temperature.4.97.0\lib\UnitsNet.Temperature.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>
@@ -81,11 +81,11 @@
       <ProjectConfigurationsDeclaredAsItems />
     </ProjectCapabilities>
   </ProjectExtensions>
-  <Import Project="packages\Nerdbank.GitVersioning.3.4.194\build\Nerdbank.GitVersioning.targets" Condition="Exists('packages\Nerdbank.GitVersioning.3.4.194\build\Nerdbank.GitVersioning.targets')" />
+  <Import Project="packages\Nerdbank.GitVersioning.3.4.220\build\Nerdbank.GitVersioning.targets" Condition="Exists('packages\Nerdbank.GitVersioning.3.4.220\build\Nerdbank.GitVersioning.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105.The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('packages\Nerdbank.GitVersioning.3.4.194\build\Nerdbank.GitVersioning.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Nerdbank.GitVersioning.3.4.194\build\Nerdbank.GitVersioning.targets'))" />
+    <Error Condition="!Exists('packages\Nerdbank.GitVersioning.3.4.220\build\Nerdbank.GitVersioning.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Nerdbank.GitVersioning.3.4.220\build\Nerdbank.GitVersioning.targets'))" />
   </Target>
 </Project>

--- a/devices/Bno055/Bno055.nuspec
+++ b/devices/Bno055/Bno055.nuspec
@@ -20,12 +20,11 @@
     <summary>Iot.Device.Bno055 assembly for .NET nanoFramework C# projects</summary>
     <tags>nanoFramework C# csharp netmf netnf Iot.Device.Bno055</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.4-preview.11" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.10.5-preview.18" />
       <dependency id="nanoFramework.Runtime.Events" version="1.9.0-preview.26" />
       <dependency id="nanoFramework.System.Device.Gpio" version="1.0.0-preview.40" />
       <dependency id="nanoFramework.System.Device.I2c" version="1.0.1-preview.33" />
       <dependency id="nanoFramework.System.Math" version="1.4.0-preview.7" />
-      <dependency id="Nerdbank.GitVersioning" version="3.4.194" developmentDependency="true" />
     </dependencies>
   </metadata>
   <files>

--- a/devices/Bno055/Bno055.sln
+++ b/devices/Bno055/Bno055.sln
@@ -1,5 +1,4 @@
-
-
+﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.31313.79

--- a/devices/Bno055/Bno055Sensor.cs
+++ b/devices/Bno055/Bno055Sensor.cs
@@ -512,7 +512,7 @@ namespace Iot.Device.Bno055
                 // If unit is Farenheit, then divide by 2, otherwise no convertion
                 if ((_units & Units.TemperatureFarenheit) == Units.TemperatureFarenheit)
                 {
-                    return Temperature.FromDegreesFahrenheit(ReadByte(Registers.TEMP) / 2.0f);
+                    return Temperature.FromDegreesFahrenheit(ReadByte(Registers.TEMP) / 2.0);
                 }
                 else
                 {

--- a/devices/Bno055/packages.config
+++ b/devices/Bno055/packages.config
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.4-preview.11" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.Runtime.Events" version="1.9.0-preview.26" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.System.Device.Gpio" version="1.0.0-preview.40" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.System.Device.I2c" version="1.0.1-preview.33" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.System.Math" version="1.4.0-preview.7" targetFramework="netnanoframework10" />
-  <package id="Nerdbank.GitVersioning" version="3.4.194" developmentDependency="true" targetFramework="netnanoframework10" />
-  <package id="UnitsNet.nanoFramework.Temperature" version="4.91.0" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.10.5-preview.18" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.Runtime.Events" version="1.9.1-preview.7" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.System.Device.Gpio" version="1.0.0-preview.48" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.System.Device.I2c" version="1.0.1-preview.38" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.System.Math" version="1.4.1-preview.7" targetFramework="netnanoframework10" />
+  <package id="Nerdbank.GitVersioning" version="3.4.220" developmentDependency="true" targetFramework="netnanoframework10" />
+  <package id="UnitsNet.nanoFramework.Temperature" version="4.97.0" targetFramework="netnanoframework10" />
 </packages>

--- a/devices/Bno055/samples/Bno055.sample.nfproj
+++ b/devices/Bno055/samples/Bno055.sample.nfproj
@@ -21,34 +21,35 @@
   </PropertyGroup>
   <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.props" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.props')" />
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.4.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.4-preview.11\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.10.5.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5-preview.18\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>
-    <Reference Include="nanoFramework.Runtime.Events, Version=1.9.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.Runtime.Events.1.9.0-preview.26\lib\nanoFramework.Runtime.Events.dll</HintPath>
+    <Reference Include="nanoFramework.Runtime.Events, Version=1.9.1.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.Runtime.Events.1.9.1-preview.7\lib\nanoFramework.Runtime.Events.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>
     <Reference Include="System.Device.Gpio, Version=1.0.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.System.Device.Gpio.1.0.0-preview.40\lib\System.Device.Gpio.dll</HintPath>
+      <HintPath>..\packages\nanoFramework.System.Device.Gpio.1.0.0-preview.48\lib\System.Device.Gpio.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>
     <Reference Include="System.Device.I2c, Version=1.0.1.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.System.Device.I2c.1.0.1-preview.33\lib\System.Device.I2c.dll</HintPath>
+      <HintPath>..\packages\nanoFramework.System.Device.I2c.1.0.1-preview.38\lib\System.Device.I2c.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>
-    <Reference Include="System.Math, Version=1.4.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.System.Math.1.4.0-preview.5\lib\System.Math.dll</HintPath>
+    <Reference Include="System.Math, Version=1.4.1.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.System.Math.1.4.1-preview.7\lib\System.Math.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>
     <Reference Include="UnitsNet.Temperature, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\packages\UnitsNet.nanoFramework.Temperature.4.94.0\lib\UnitsNet.Temperature.dll</HintPath>
+      <HintPath>..\packages\UnitsNet.nanoFramework.Temperature.4.97.0\lib\UnitsNet.Temperature.dll</HintPath>
       <Private>True</Private>
+      <SpecificVersion>True</SpecificVersion>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/devices/Bno055/samples/packages.config
+++ b/devices/Bno055/samples/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.4-preview.11" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.Runtime.Events" version="1.9.0-preview.26" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.System.Device.Gpio" version="1.0.0-preview.40" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.System.Device.I2c" version="1.0.1-preview.33" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.System.Math" version="1.4.0-preview.5" targetFramework="netnanoframework10" />
-  <package id="UnitsNet.nanoFramework.Temperature" version="4.94.0" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.10.5-preview.18" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.Runtime.Events" version="1.9.1-preview.7" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.System.Device.Gpio" version="1.0.0-preview.48" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.System.Device.I2c" version="1.0.1-preview.38" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.System.Math" version="1.4.1-preview.7" targetFramework="netnanoframework10" />
+  <package id="UnitsNet.nanoFramework.Temperature" version="4.97.0" targetFramework="netnanoframework10" />
 </packages>

--- a/devices/Ccs811/Ccs811.nfproj
+++ b/devices/Ccs811/Ccs811.nfproj
@@ -20,8 +20,8 @@
   </PropertyGroup>
   <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.props" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.props')" />
   <ItemGroup>
-    <Reference Include="mscorlib">
-      <HintPath>packages\nanoFramework.CoreLibrary.1.10.4-preview.11\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.10.5.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>packages\nanoFramework.CoreLibrary.1.10.5-preview.18\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nanoFramework.Runtime.Events, Version=1.9.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
@@ -34,7 +34,7 @@
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>
-    <Reference Include="System.Device.I2c">
+    <Reference Include="System.Device.I2c, Version=1.0.1.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>packages\nanoFramework.System.Device.I2c.1.0.1-preview.33\lib\System.Device.I2c.dll</HintPath>
       <Private>True</Private>
     </Reference>

--- a/devices/Ccs811/packages.config
+++ b/devices/Ccs811/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.4-preview.11" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.10.5-preview.18" targetFramework="netnanoframework10" />
   <package id="nanoFramework.Runtime.Events" version="1.9.0-preview.26" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Device.Gpio" version="1.0.0-preview.40" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Device.I2c" version="1.0.1-preview.33" targetFramework="netnanoframework10" />

--- a/devices/Dhtxx/Dhtxx.nfproj
+++ b/devices/Dhtxx/Dhtxx.nfproj
@@ -29,8 +29,8 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.4.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>packages\nanoFramework.CoreLibrary.1.10.4-preview.11\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.10.5.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>packages\nanoFramework.CoreLibrary.1.10.5-preview.18\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/devices/Dhtxx/Dhtxx.nuspec
+++ b/devices/Dhtxx/Dhtxx.nuspec
@@ -20,7 +20,7 @@
     <summary>Iot.Device.Dhtxx assembly for .NET nanoFramework C# projects</summary>
     <tags>nanoFramework C# csharp netmf netnf Iot.Device.Dhtxx</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.4-preview.11" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.10.5-preview.18" />
       <dependency id="nanoFramework.Runtime.Events" version="1.9.0-preview.26" />
       <dependency id="nanoFramework.System.Device.Gpio" version="1.0.0-preview.40" />
       <dependency id="nanoFramework.System.Device.I2c" version="1.0.1-preview.33" />

--- a/devices/Dhtxx/packages.config
+++ b/devices/Dhtxx/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.4-preview.11" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.10.5-preview.18" targetFramework="netnanoframework10" />
   <package id="nanoFramework.Runtime.Events" version="1.9.0-preview.26" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Device.Gpio" version="1.0.0-preview.40" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Device.I2c" version="1.0.1-preview.33" targetFramework="netnanoframework10" />

--- a/devices/Dhtxx/samples/Dhtxx-Sample.nfproj
+++ b/devices/Dhtxx/samples/Dhtxx-Sample.nfproj
@@ -22,8 +22,8 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib">
-      <HintPath>packages\nanoFramework.CoreLibrary.1.10.4-preview.11\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.10.5.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>packages\nanoFramework.CoreLibrary.1.10.5-preview.18\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nanoFramework.Runtime.Events">

--- a/devices/Dhtxx/samples/packages.config
+++ b/devices/Dhtxx/samples/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.4-preview.11" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.10.5-preview.18" targetFramework="netnanoframework10" />
   <package id="nanoFramework.Runtime.Events" version="1.9.0-preview.25" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Device.Gpio" version="1.0.0-preview.39" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Device.I2c" version="1.0.1-preview.32" targetFramework="netnanoframework10" />

--- a/devices/Hcsr04/Hcsr04.nfproj
+++ b/devices/Hcsr04/Hcsr04.nfproj
@@ -19,8 +19,8 @@
   </PropertyGroup>
   <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.props" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.props')" />
   <ItemGroup>
-    <Reference Include="mscorlib">
-      <HintPath>packages\nanoFramework.CoreLibrary.1.10.4-preview.11\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.10.5.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>packages\nanoFramework.CoreLibrary.1.10.5-preview.18\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nanoFramework.Runtime.Events, Version=1.9.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">

--- a/devices/Hcsr04/packages.config
+++ b/devices/Hcsr04/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.4-preview.11" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.10.5-preview.18" targetFramework="netnanoframework10" />
   <package id="nanoFramework.Runtime.Events" version="1.9.0-preview.26" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Device.Gpio" version="1.0.0-preview.40" targetFramework="netnanoframework10" />
   <package id="UnitsNet.nanoFramework.Length" version="4.91.0" targetFramework="netnanoframework10" />

--- a/devices/Hcsr501/Hcsr501.nfproj
+++ b/devices/Hcsr501/Hcsr501.nfproj
@@ -30,8 +30,8 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.4.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>packages\nanoFramework.CoreLibrary.1.10.4-preview.11\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.10.5.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>packages\nanoFramework.CoreLibrary.1.10.5-preview.18\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/devices/Hcsr501/packages.config
+++ b/devices/Hcsr501/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.4-preview.11" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.10.5-preview.18" targetFramework="netnanoframework10" />
   <package id="nanoFramework.Runtime.Events" version="1.9.0-preview.26" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Device.Gpio" version="1.0.0-preview.40" targetFramework="netnanoframework10" />
   <package id="Nerdbank.GitVersioning" version="3.4.194" targetFramework="netnanoframework10" developmentDependency="true" />

--- a/devices/Hmc5883l/Hmc5883l.nfproj
+++ b/devices/Hmc5883l/Hmc5883l.nfproj
@@ -21,11 +21,11 @@
   </PropertyGroup>
   <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.props" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.props')" />
   <ItemGroup>
-    <Reference Include="mscorlib">
-      <HintPath>packages\nanoFramework.CoreLibrary.1.10.4-preview.11\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.10.5.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>packages\nanoFramework.CoreLibrary.1.10.5-preview.18\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Device.I2c">
+    <Reference Include="System.Device.I2c, Version=1.0.1.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>packages\nanoFramework.System.Device.I2c.1.0.1-preview.33\lib\System.Device.I2c.dll</HintPath>
       <Private>True</Private>
     </Reference>

--- a/devices/Hmc5883l/packages.config
+++ b/devices/Hmc5883l/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.4-preview.11" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.10.5-preview.18" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Device.I2c" version="1.0.1-preview.33" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Math" version="1.4.0-preview.7" targetFramework="netnanoframework10" />
   <package id="Nerdbank.GitVersioning" version="3.4.194" developmentDependency="true" targetFramework="netnanoframework10" />

--- a/devices/Hts221/Hts221.nfproj
+++ b/devices/Hts221/Hts221.nfproj
@@ -20,11 +20,11 @@
   </PropertyGroup>
   <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.props" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.props')" />
   <ItemGroup>
-    <Reference Include="mscorlib">
-      <HintPath>packages\nanoFramework.CoreLibrary.1.10.4-preview.11\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.10.5.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>packages\nanoFramework.CoreLibrary.1.10.5-preview.18\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Device.I2c">
+    <Reference Include="System.Device.I2c, Version=1.0.1.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>packages\nanoFramework.System.Device.I2c.1.0.1-preview.33\lib\System.Device.I2c.dll</HintPath>
       <Private>True</Private>
     </Reference>

--- a/devices/Hts221/packages.config
+++ b/devices/Hts221/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.4-preview.11" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.10.5-preview.18" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Device.I2c" version="1.0.1-preview.33" targetFramework="netnanoframework10" />
   <package id="Nerdbank.GitVersioning" version="3.4.194" developmentDependency="true" targetFramework="netnanoframework10" />
   <package id="UnitsNet.nanoFramework.RelativeHumidity" version="4.92.1" targetFramework="netnanoframework10" />

--- a/devices/KeyMatrix/KeyMatrix.nfproj
+++ b/devices/KeyMatrix/KeyMatrix.nfproj
@@ -20,8 +20,8 @@
   </PropertyGroup>
   <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.props" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.props')" />
   <ItemGroup>
-    <Reference Include="mscorlib">
-      <HintPath>packages\nanoFramework.CoreLibrary.1.10.4-preview.11\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.10.5.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>packages\nanoFramework.CoreLibrary.1.10.5-preview.18\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nanoFramework.Runtime.Events, Version=1.9.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">

--- a/devices/KeyMatrix/packages.config
+++ b/devices/KeyMatrix/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.4-preview.11" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.10.5-preview.18" targetFramework="netnanoframework10" />
   <package id="nanoFramework.Runtime.Events" version="1.9.0-preview.26" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Device.Gpio" version="1.0.0-preview.40" targetFramework="netnanoframework10" />
   <package id="Nerdbank.GitVersioning" version="3.4.194" developmentDependency="true" targetFramework="netnanoframework10" />

--- a/devices/LidarLiteV3/LidarLiteV3.nfproj
+++ b/devices/LidarLiteV3/LidarLiteV3.nfproj
@@ -20,8 +20,8 @@
   </PropertyGroup>
   <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.props" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.props')" />
   <ItemGroup>
-    <Reference Include="mscorlib">
-      <HintPath>packages\nanoFramework.CoreLibrary.1.10.4-preview.11\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.10.5.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>packages\nanoFramework.CoreLibrary.1.10.5-preview.18\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nanoFramework.Runtime.Events, Version=1.9.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
@@ -34,7 +34,7 @@
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>
-    <Reference Include="System.Device.I2c">
+    <Reference Include="System.Device.I2c, Version=1.0.1.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>packages\nanoFramework.System.Device.I2c.1.0.1-preview.33\lib\System.Device.I2c.dll</HintPath>
       <Private>True</Private>
     </Reference>

--- a/devices/LidarLiteV3/packages.config
+++ b/devices/LidarLiteV3/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.4-preview.11" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.10.5-preview.18" targetFramework="netnanoframework10" />
   <package id="nanoFramework.Runtime.Events" version="1.9.0-preview.26" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Device.Gpio" version="1.0.0-preview.40" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Device.I2c" version="1.0.1-preview.33" targetFramework="netnanoframework10" />

--- a/devices/LiquidLevel/LiquidLevel.nfproj
+++ b/devices/LiquidLevel/LiquidLevel.nfproj
@@ -20,8 +20,8 @@
   </PropertyGroup>
   <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.props" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.props')" />
   <ItemGroup>
-    <Reference Include="mscorlib">
-      <HintPath>packages\nanoFramework.CoreLibrary.1.10.4-preview.11\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.10.5.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>packages\nanoFramework.CoreLibrary.1.10.5-preview.18\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nanoFramework.Runtime.Events, Version=1.9.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">

--- a/devices/LiquidLevel/packages.config
+++ b/devices/LiquidLevel/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.4-preview.11" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.10.5-preview.18" targetFramework="netnanoframework10" />
   <package id="nanoFramework.Runtime.Events" version="1.9.0-preview.26" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Device.Gpio" version="1.0.0-preview.40" targetFramework="netnanoframework10" />
   <package id="Nerdbank.GitVersioning" version="3.4.194" developmentDependency="true" targetFramework="netnanoframework10" />

--- a/devices/LiquidLevel/samples/Llc200d3sh.Sample.nfproj
+++ b/devices/LiquidLevel/samples/Llc200d3sh.Sample.nfproj
@@ -21,7 +21,7 @@
   <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.props" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.props')" />
   <ItemGroup>
     <Reference Include="mscorlib">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.4-preview.11\lib\mscorlib.dll</HintPath>
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5-preview.18\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nanoFramework.Runtime.Events, Version=1.9.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">

--- a/devices/Lm75/Lm75.nfproj
+++ b/devices/Lm75/Lm75.nfproj
@@ -20,11 +20,11 @@
   </PropertyGroup>
   <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.props" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.props')" />
   <ItemGroup>
-    <Reference Include="mscorlib">
-      <HintPath>packages\nanoFramework.CoreLibrary.1.10.4-preview.11\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.10.5.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>packages\nanoFramework.CoreLibrary.1.10.5-preview.18\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Device.I2c">
+    <Reference Include="System.Device.I2c, Version=1.0.1.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>packages\nanoFramework.System.Device.I2c.1.0.1-preview.33\lib\System.Device.I2c.dll</HintPath>
       <Private>True</Private>
     </Reference>

--- a/devices/Lm75/packages.config
+++ b/devices/Lm75/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.4-preview.11" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.10.5-preview.18" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Device.I2c" version="1.0.1-preview.33" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Math" version="1.4.0-preview.7" targetFramework="netnanoframework10" />
   <package id="Nerdbank.GitVersioning" version="3.4.194" developmentDependency="true" targetFramework="netnanoframework10" />

--- a/devices/Lps25h/Lps25h.nfproj
+++ b/devices/Lps25h/Lps25h.nfproj
@@ -20,11 +20,11 @@
   </PropertyGroup>
   <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.props" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.props')" />
   <ItemGroup>
-    <Reference Include="mscorlib">
-      <HintPath>packages\nanoFramework.CoreLibrary.1.10.4-preview.11\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.10.5.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>packages\nanoFramework.CoreLibrary.1.10.5-preview.18\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Device.I2c">
+    <Reference Include="System.Device.I2c, Version=1.0.1.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>packages\nanoFramework.System.Device.I2c.1.0.1-preview.33\lib\System.Device.I2c.dll</HintPath>
       <Private>True</Private>
     </Reference>

--- a/devices/Lps25h/packages.config
+++ b/devices/Lps25h/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.4-preview.11" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.10.5-preview.18" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Device.I2c" version="1.0.1-preview.33" targetFramework="netnanoframework10" />
   <package id="Nerdbank.GitVersioning" version="3.4.194" developmentDependency="true" targetFramework="netnanoframework10" />
   <package id="UnitsNet.nanoFramework.Pressure" version="4.92.1" targetFramework="netnanoframework10" />

--- a/devices/Lsm9Ds1/Lsm9Ds1.nfproj
+++ b/devices/Lsm9Ds1/Lsm9Ds1.nfproj
@@ -21,11 +21,11 @@
   </PropertyGroup>
   <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.props" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.props')" />
   <ItemGroup>
-    <Reference Include="mscorlib">
-      <HintPath>packages\nanoFramework.CoreLibrary.1.10.4-preview.11\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.10.5.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>packages\nanoFramework.CoreLibrary.1.10.5-preview.18\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Device.I2c">
+    <Reference Include="System.Device.I2c, Version=1.0.1.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>packages\nanoFramework.System.Device.I2c.1.0.1-preview.33\lib\System.Device.I2c.dll</HintPath>
       <Private>True</Private>
     </Reference>

--- a/devices/Lsm9Ds1/packages.config
+++ b/devices/Lsm9Ds1/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.4-preview.11" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.10.5-preview.18" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Device.I2c" version="1.0.1-preview.33" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Math" version="1.4.0-preview.7" targetFramework="netnanoframework10" />
   <package id="Nerdbank.GitVersioning" version="3.4.194" developmentDependency="true" targetFramework="netnanoframework10" />

--- a/devices/Max31856/Max31856.nfproj
+++ b/devices/Max31856/Max31856.nfproj
@@ -20,8 +20,8 @@
   </PropertyGroup>
   <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.props" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.props')" />
   <ItemGroup>
-    <Reference Include="mscorlib">
-      <HintPath>packages\nanoFramework.CoreLibrary.1.10.4-preview.11\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.10.5.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>packages\nanoFramework.CoreLibrary.1.10.5-preview.18\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Device.Spi">

--- a/devices/Max31856/packages.config
+++ b/devices/Max31856/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.4-preview.11" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.10.5-preview.18" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Device.Spi" version="1.0.0-preview.38" targetFramework="netnanoframework10" />
   <package id="Nerdbank.GitVersioning" version="3.4.194" developmentDependency="true" targetFramework="netnanoframework10" />
   <package id="UnitsNet.nanoFramework.Frequency" version="4.92.1" targetFramework="netnanoframework10" />

--- a/devices/Max31865/Max31865.nfproj
+++ b/devices/Max31865/Max31865.nfproj
@@ -20,8 +20,8 @@
   </PropertyGroup>
   <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.props" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.props')" />
   <ItemGroup>
-    <Reference Include="mscorlib">
-      <HintPath>packages\nanoFramework.CoreLibrary.1.10.4-preview.11\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.10.5.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>packages\nanoFramework.CoreLibrary.1.10.5-preview.18\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Device.Spi">

--- a/devices/Max31865/packages.config
+++ b/devices/Max31865/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.4-preview.11" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.10.5-preview.18" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Device.Spi" version="1.0.0-preview.38" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Math" version="1.4.0-preview.7" targetFramework="netnanoframework10" />
   <package id="Nerdbank.GitVersioning" version="3.4.194" developmentDependency="true" targetFramework="netnanoframework10" />

--- a/devices/Max44009/Max44009.nfproj
+++ b/devices/Max44009/Max44009.nfproj
@@ -20,11 +20,11 @@
   </PropertyGroup>
   <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.props" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.props')" />
   <ItemGroup>
-    <Reference Include="mscorlib">
-      <HintPath>packages\nanoFramework.CoreLibrary.1.10.4-preview.11\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.10.5.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>packages\nanoFramework.CoreLibrary.1.10.5-preview.18\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Device.I2c">
+    <Reference Include="System.Device.I2c, Version=1.0.1.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>packages\nanoFramework.System.Device.I2c.1.0.1-preview.33\lib\System.Device.I2c.dll</HintPath>
       <Private>True</Private>
     </Reference>

--- a/devices/Max44009/packages.config
+++ b/devices/Max44009/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.4-preview.11" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.10.5-preview.18" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Device.I2c" version="1.0.1-preview.33" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Math" version="1.4.0-preview.7" targetFramework="netnanoframework10" />
   <package id="Nerdbank.GitVersioning" version="3.4.194" developmentDependency="true" targetFramework="netnanoframework10" />

--- a/devices/Max7219/Max7219.nfproj
+++ b/devices/Max7219/Max7219.nfproj
@@ -20,8 +20,8 @@
   </PropertyGroup>
   <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.props" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.props')" />
   <ItemGroup>
-    <Reference Include="mscorlib">
-      <HintPath>packages\nanoFramework.CoreLibrary.1.10.4-preview.11\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.10.5.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>packages\nanoFramework.CoreLibrary.1.10.5-preview.18\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Device.Spi">

--- a/devices/Max7219/packages.config
+++ b/devices/Max7219/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.4-preview.11" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.10.5-preview.18" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Device.Spi" version="1.0.0-preview.38" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Math" version="1.4.0-preview.7" targetFramework="netnanoframework10" />
   <package id="Nerdbank.GitVersioning" version="3.4.194" developmentDependency="true" targetFramework="netnanoframework10" />

--- a/devices/Mbi5027/samples/Mbi5027-driver.nfproj
+++ b/devices/Mbi5027/samples/Mbi5027-driver.nfproj
@@ -21,7 +21,7 @@
   <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.props" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.props')" />
   <ItemGroup>
     <Reference Include="mscorlib">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.4-preview.11\lib\mscorlib.dll</HintPath>
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5-preview.18\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nanoFramework.Runtime.Events, Version=1.9.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">

--- a/devices/Mbi5027/samples/packages.config
+++ b/devices/Mbi5027/samples/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.4-preview.11" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.10.5-preview.18" targetFramework="netnanoframework10" />
   <package id="nanoFramework.Runtime.Events" version="1.9.0-preview.26" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Device.Gpio" version="1.0.0-preview.40" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Device.Spi" version="1.0.0-preview.42" targetFramework="netnanoframework10" />

--- a/devices/Mcp25xxx/Mcp25xxx.nfproj
+++ b/devices/Mcp25xxx/Mcp25xxx.nfproj
@@ -20,8 +20,8 @@
   </PropertyGroup>
   <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.props" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.props')" />
   <ItemGroup>
-    <Reference Include="mscorlib">
-      <HintPath>packages\nanoFramework.CoreLibrary.1.10.4-preview.11\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.10.5.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>packages\nanoFramework.CoreLibrary.1.10.5-preview.18\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nanoFramework.Runtime.Events, Version=1.9.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">

--- a/devices/Mcp25xxx/packages.config
+++ b/devices/Mcp25xxx/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.4-preview.11" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.10.5-preview.18" targetFramework="netnanoframework10" />
   <package id="nanoFramework.Runtime.Events" version="1.9.0-preview.26" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Device.Gpio" version="1.0.0-preview.40" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Device.Spi" version="1.0.0-preview.38" targetFramework="netnanoframework10" />

--- a/devices/Mcp3428/Mcp3428.nfproj
+++ b/devices/Mcp3428/Mcp3428.nfproj
@@ -25,7 +25,7 @@
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>
-    <Reference Include="System.Device.I2c">
+    <Reference Include="System.Device.I2c, Version=1.0.1.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>packages\nanoFramework.System.Device.I2c.1.0.1-preview.33\lib\System.Device.I2c.dll</HintPath>
       <Private>True</Private>
     </Reference>

--- a/devices/Mcp3xxx/Mcp3xxx.nfproj
+++ b/devices/Mcp3xxx/Mcp3xxx.nfproj
@@ -20,8 +20,8 @@
   </PropertyGroup>
   <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.props" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.props')" />
   <ItemGroup>
-    <Reference Include="mscorlib">
-      <HintPath>packages\nanoFramework.CoreLibrary.1.10.4-preview.11\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.10.5.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>packages\nanoFramework.CoreLibrary.1.10.5-preview.18\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Device.Spi">

--- a/devices/Mcp3xxx/packages.config
+++ b/devices/Mcp3xxx/packages.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.4-preview.11" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.10.5-preview.18" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Device.Spi" version="1.0.0-preview.38" targetFramework="netnanoframework10" />
   <package id="Nerdbank.GitVersioning" version="3.4.194" developmentDependency="true" targetFramework="netnanoframework10" />
 </packages>

--- a/devices/Mcp9808/Mcp9808.nfproj
+++ b/devices/Mcp9808/Mcp9808.nfproj
@@ -20,11 +20,11 @@
   </PropertyGroup>
   <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.props" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.props')" />
   <ItemGroup>
-    <Reference Include="mscorlib">
-      <HintPath>packages\nanoFramework.CoreLibrary.1.10.4-preview.11\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.10.5.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>packages\nanoFramework.CoreLibrary.1.10.5-preview.18\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Device.I2c">
+    <Reference Include="System.Device.I2c, Version=1.0.1.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>packages\nanoFramework.System.Device.I2c.1.0.1-preview.33\lib\System.Device.I2c.dll</HintPath>
       <Private>True</Private>
     </Reference>

--- a/devices/Mcp9808/packages.config
+++ b/devices/Mcp9808/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.4-preview.11" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.10.5-preview.18" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Device.I2c" version="1.0.1-preview.33" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Math" version="1.4.0-preview.7" targetFramework="netnanoframework10" />
   <package id="Nerdbank.GitVersioning" version="3.4.194" developmentDependency="true" targetFramework="netnanoframework10" />

--- a/devices/Mlx90614/Mlx90614.nfproj
+++ b/devices/Mlx90614/Mlx90614.nfproj
@@ -20,11 +20,11 @@
   </PropertyGroup>
   <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.props" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.props')" />
   <ItemGroup>
-    <Reference Include="mscorlib">
-      <HintPath>packages\nanoFramework.CoreLibrary.1.10.4-preview.11\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.10.5.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>packages\nanoFramework.CoreLibrary.1.10.5-preview.18\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Device.I2c">
+    <Reference Include="System.Device.I2c, Version=1.0.1.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>packages\nanoFramework.System.Device.I2c.1.0.1-preview.33\lib\System.Device.I2c.dll</HintPath>
       <Private>True</Private>
     </Reference>

--- a/devices/Mlx90614/packages.config
+++ b/devices/Mlx90614/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.4-preview.11" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.10.5-preview.18" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Device.I2c" version="1.0.1-preview.33" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Math" version="1.4.0-preview.7" targetFramework="netnanoframework10" />
   <package id="Nerdbank.GitVersioning" version="3.4.194" developmentDependency="true" targetFramework="netnanoframework10" />

--- a/devices/Mpr121/Mpr121.nfproj
+++ b/devices/Mpr121/Mpr121.nfproj
@@ -20,11 +20,11 @@
   </PropertyGroup>
   <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.props" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.props')" />
   <ItemGroup>
-    <Reference Include="mscorlib">
-      <HintPath>packages\nanoFramework.CoreLibrary.1.10.4-preview.11\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.10.5.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>packages\nanoFramework.CoreLibrary.1.10.5-preview.18\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Device.I2c">
+    <Reference Include="System.Device.I2c, Version=1.0.1.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>packages\nanoFramework.System.Device.I2c.1.0.1-preview.33\lib\System.Device.I2c.dll</HintPath>
       <Private>True</Private>
     </Reference>

--- a/devices/Mpr121/packages.config
+++ b/devices/Mpr121/packages.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.4-preview.11" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.10.5-preview.18" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Device.I2c" version="1.0.1-preview.33" targetFramework="netnanoframework10" />
   <package id="Nerdbank.GitVersioning" version="3.4.194" developmentDependency="true" targetFramework="netnanoframework10" />
 </packages>

--- a/devices/Mpu9250/Mpu9250.nfproj
+++ b/devices/Mpu9250/Mpu9250.nfproj
@@ -20,11 +20,11 @@
   </PropertyGroup>
   <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.props" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.props')" />
   <ItemGroup>
-    <Reference Include="mscorlib">
-      <HintPath>packages\nanoFramework.CoreLibrary.1.10.4-preview.11\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.10.5.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>packages\nanoFramework.CoreLibrary.1.10.5-preview.18\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Device.I2c">
+    <Reference Include="System.Device.I2c, Version=1.0.1.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>packages\nanoFramework.System.Device.I2c.1.0.1-preview.33\lib\System.Device.I2c.dll</HintPath>
       <Private>True</Private>
     </Reference>

--- a/devices/Mpu9250/packages.config
+++ b/devices/Mpu9250/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.4-preview.11" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.10.5-preview.18" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Device.I2c" version="1.0.1-preview.33" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Math" version="1.4.0-preview.7" targetFramework="netnanoframework10" />
   <package id="Nerdbank.GitVersioning" version="3.4.194" developmentDependency="true" targetFramework="netnanoframework10" />

--- a/devices/Nrf24l01/Nrf24l01.nfproj
+++ b/devices/Nrf24l01/Nrf24l01.nfproj
@@ -20,8 +20,8 @@
   </PropertyGroup>
   <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.props" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.props')" />
   <ItemGroup>
-    <Reference Include="mscorlib">
-      <HintPath>packages\nanoFramework.CoreLibrary.1.10.4-preview.11\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.10.5.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>packages\nanoFramework.CoreLibrary.1.10.5-preview.18\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nanoFramework.Runtime.Events, Version=1.9.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">

--- a/devices/Nrf24l01/packages.config
+++ b/devices/Nrf24l01/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.4-preview.11" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.10.5-preview.18" targetFramework="netnanoframework10" />
   <package id="nanoFramework.Runtime.Events" version="1.9.0-preview.26" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Device.Gpio" version="1.0.0-preview.40" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Device.Spi" version="1.0.0-preview.38" targetFramework="netnanoframework10" />

--- a/devices/Pca95x4/Pca95x4.nfproj
+++ b/devices/Pca95x4/Pca95x4.nfproj
@@ -20,8 +20,8 @@
   </PropertyGroup>
   <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.props" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.props')" />
   <ItemGroup>
-    <Reference Include="mscorlib">
-      <HintPath>packages\nanoFramework.CoreLibrary.1.10.4-preview.11\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.10.5.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>packages\nanoFramework.CoreLibrary.1.10.5-preview.18\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nanoFramework.Runtime.Events, Version=1.9.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
@@ -34,7 +34,7 @@
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>
-    <Reference Include="System.Device.I2c">
+    <Reference Include="System.Device.I2c, Version=1.0.1.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>packages\nanoFramework.System.Device.I2c.1.0.1-preview.33\lib\System.Device.I2c.dll</HintPath>
       <Private>True</Private>
     </Reference>

--- a/devices/Pca95x4/packages.config
+++ b/devices/Pca95x4/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.4-preview.11" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.10.5-preview.18" targetFramework="netnanoframework10" />
   <package id="nanoFramework.Runtime.Events" version="1.9.0-preview.26" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Device.Gpio" version="1.0.0-preview.40" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Device.I2c" version="1.0.1-preview.33" targetFramework="netnanoframework10" />

--- a/devices/RadioReceiver/RadioReceiver.nfproj
+++ b/devices/RadioReceiver/RadioReceiver.nfproj
@@ -20,11 +20,11 @@
   </PropertyGroup>
   <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.props" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.props')" />
   <ItemGroup>
-    <Reference Include="mscorlib">
-      <HintPath>packages\nanoFramework.CoreLibrary.1.10.4-preview.11\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.10.5.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>packages\nanoFramework.CoreLibrary.1.10.5-preview.18\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Device.I2c">
+    <Reference Include="System.Device.I2c, Version=1.0.1.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>packages\nanoFramework.System.Device.I2c.1.0.1-preview.33\lib\System.Device.I2c.dll</HintPath>
       <Private>True</Private>
     </Reference>

--- a/devices/RadioReceiver/packages.config
+++ b/devices/RadioReceiver/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.4-preview.11" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.10.5-preview.18" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Device.I2c" version="1.0.1-preview.33" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Math" version="1.4.0-preview.9" targetFramework="netnanoframework10" />
   <package id="Nerdbank.GitVersioning" version="3.4.203" developmentDependency="true" targetFramework="netnanoframework10" />

--- a/devices/RadioTransmitter/RadioTransmitter.nfproj
+++ b/devices/RadioTransmitter/RadioTransmitter.nfproj
@@ -20,11 +20,11 @@
   </PropertyGroup>
   <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.props" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.props')" />
   <ItemGroup>
-    <Reference Include="mscorlib">
-      <HintPath>packages\nanoFramework.CoreLibrary.1.10.4-preview.11\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.10.5.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>packages\nanoFramework.CoreLibrary.1.10.5-preview.18\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Device.I2c">
+    <Reference Include="System.Device.I2c, Version=1.0.1.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>packages\nanoFramework.System.Device.I2c.1.0.1-preview.33\lib\System.Device.I2c.dll</HintPath>
       <Private>True</Private>
     </Reference>

--- a/devices/RadioTransmitter/packages.config
+++ b/devices/RadioTransmitter/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.4-preview.11" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.10.5-preview.18" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Device.I2c" version="1.0.1-preview.33" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Math" version="1.4.0-preview.9" targetFramework="netnanoframework10" />
   <package id="Nerdbank.GitVersioning" version="3.4.203" developmentDependency="true" targetFramework="netnanoframework10" />

--- a/devices/RotaryEncoder/RotaryEncoder.nfproj
+++ b/devices/RotaryEncoder/RotaryEncoder.nfproj
@@ -30,8 +30,8 @@
     <None Include="*.md" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.4.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>packages\nanoFramework.CoreLibrary.1.10.4-preview.11\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.10.5.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>packages\nanoFramework.CoreLibrary.1.10.5-preview.18\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/devices/RotaryEncoder/packages.config
+++ b/devices/RotaryEncoder/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.4-preview.11" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.10.5-preview.18" targetFramework="netnanoframework10" />
   <package id="nanoFramework.Runtime.Events" version="1.9.0-preview.26" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Device.Gpio" version="1.0.0-preview.40" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Math" version="1.4.0-preview.7" targetFramework="netnanoframework10" />

--- a/devices/Rtc/Rtc.nfproj
+++ b/devices/Rtc/Rtc.nfproj
@@ -20,11 +20,11 @@
   </PropertyGroup>
   <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.props" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.props')" />
   <ItemGroup>
-    <Reference Include="mscorlib">
-      <HintPath>packages\nanoFramework.CoreLibrary.1.10.4-preview.11\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.10.5.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>packages\nanoFramework.CoreLibrary.1.10.5-preview.18\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Device.I2c">
+    <Reference Include="System.Device.I2c, Version=1.0.1.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>packages\nanoFramework.System.Device.I2c.1.0.1-preview.33\lib\System.Device.I2c.dll</HintPath>
       <Private>True</Private>
     </Reference>

--- a/devices/Rtc/packages.config
+++ b/devices/Rtc/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.4-preview.11" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.10.5-preview.18" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Device.I2c" version="1.0.1-preview.33" targetFramework="netnanoframework10" />
   <package id="Nerdbank.GitVersioning" version="3.4.203" developmentDependency="true" targetFramework="netnanoframework10" />
   <package id="UnitsNet.nanoFramework.Temperature" version="4.92.1" targetFramework="netnanoframework10" />

--- a/devices/Sht3x/Sht3x.nfproj
+++ b/devices/Sht3x/Sht3x.nfproj
@@ -20,11 +20,11 @@
   </PropertyGroup>
   <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.props" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.props')" />
   <ItemGroup>
-    <Reference Include="mscorlib">
-      <HintPath>packages\nanoFramework.CoreLibrary.1.10.4-preview.11\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.10.5.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>packages\nanoFramework.CoreLibrary.1.10.5-preview.18\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Device.I2c">
+    <Reference Include="System.Device.I2c, Version=1.0.1.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>packages\nanoFramework.System.Device.I2c.1.0.1-preview.33\lib\System.Device.I2c.dll</HintPath>
       <Private>True</Private>
     </Reference>

--- a/devices/Sht3x/packages.config
+++ b/devices/Sht3x/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.4-preview.11" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.10.5-preview.18" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Device.I2c" version="1.0.1-preview.33" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Math" version="1.4.0-preview.9" targetFramework="netnanoframework10" />
   <package id="Nerdbank.GitVersioning" version="3.4.194" developmentDependency="true" targetFramework="netnanoframework10" />

--- a/devices/Shtc3/Shtc3.nfproj
+++ b/devices/Shtc3/Shtc3.nfproj
@@ -20,11 +20,11 @@
   </PropertyGroup>
   <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.props" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.props')" />
   <ItemGroup>
-    <Reference Include="mscorlib">
-      <HintPath>packages\nanoFramework.CoreLibrary.1.10.4-preview.11\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.10.5.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>packages\nanoFramework.CoreLibrary.1.10.5-preview.18\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Device.I2c">
+    <Reference Include="System.Device.I2c, Version=1.0.1.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>packages\nanoFramework.System.Device.I2c.1.0.1-preview.33\lib\System.Device.I2c.dll</HintPath>
       <Private>True</Private>
     </Reference>

--- a/devices/Shtc3/packages.config
+++ b/devices/Shtc3/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.4-preview.11" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.10.5-preview.18" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Device.I2c" version="1.0.1-preview.33" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Math" version="1.4.0-preview.9" targetFramework="netnanoframework10" />
   <package id="Nerdbank.GitVersioning" version="3.4.194" developmentDependency="true" targetFramework="netnanoframework10" />

--- a/devices/Si7021/Si7021.nfproj
+++ b/devices/Si7021/Si7021.nfproj
@@ -20,11 +20,11 @@
   </PropertyGroup>
   <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.props" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.props')" />
   <ItemGroup>
-    <Reference Include="mscorlib">
-      <HintPath>packages\nanoFramework.CoreLibrary.1.10.4-preview.11\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.10.5.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>packages\nanoFramework.CoreLibrary.1.10.5-preview.18\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Device.I2c">
+    <Reference Include="System.Device.I2c, Version=1.0.1.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>packages\nanoFramework.System.Device.I2c.1.0.1-preview.33\lib\System.Device.I2c.dll</HintPath>
       <Private>True</Private>
     </Reference>

--- a/devices/Si7021/packages.config
+++ b/devices/Si7021/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.4-preview.11" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.10.5-preview.18" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Device.I2c" version="1.0.1-preview.33" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Math" version="1.4.0-preview.9" targetFramework="netnanoframework10" />
   <package id="Nerdbank.GitVersioning" version="3.4.194" developmentDependency="true" targetFramework="netnanoframework10" />

--- a/devices/Sn74hc595/Sn74hc595.nfproj
+++ b/devices/Sn74hc595/Sn74hc595.nfproj
@@ -20,8 +20,8 @@
   </PropertyGroup>
   <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.props" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.props')" />
   <ItemGroup>
-    <Reference Include="mscorlib">
-      <HintPath>packages\nanoFramework.CoreLibrary.1.10.4-preview.11\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.10.5.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>packages\nanoFramework.CoreLibrary.1.10.5-preview.18\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nanoFramework.Runtime.Events, Version=1.9.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">

--- a/devices/Sn74hc595/packages.config
+++ b/devices/Sn74hc595/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.4-preview.11" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.10.5-preview.18" targetFramework="netnanoframework10" />
   <package id="nanoFramework.Runtime.Events" version="1.9.0-preview.26" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Device.Gpio" version="1.0.0-preview.40" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Device.Spi" version="1.0.0-preview.40" targetFramework="netnanoframework10" />

--- a/devices/Ssd13xx/Ssd13xx.nfproj
+++ b/devices/Ssd13xx/Ssd13xx.nfproj
@@ -20,11 +20,11 @@
   </PropertyGroup>
   <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.props" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.props')" />
   <ItemGroup>
-    <Reference Include="mscorlib">
-      <HintPath>packages\nanoFramework.CoreLibrary.1.10.4-preview.11\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.10.5.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>packages\nanoFramework.CoreLibrary.1.10.5-preview.18\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Device.I2c">
+    <Reference Include="System.Device.I2c, Version=1.0.1.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>packages\nanoFramework.System.Device.I2c.1.0.1-preview.33\lib\System.Device.I2c.dll</HintPath>
       <Private>True</Private>
     </Reference>

--- a/devices/Ssd13xx/packages.config
+++ b/devices/Ssd13xx/packages.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.4-preview.11" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.10.5-preview.18" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Device.I2c" version="1.0.1-preview.33" targetFramework="netnanoframework10" />
   <package id="Nerdbank.GitVersioning" version="3.4.194" developmentDependency="true" targetFramework="netnanoframework10" />
 </packages>

--- a/devices/Uln2003/Uln2003.nfproj
+++ b/devices/Uln2003/Uln2003.nfproj
@@ -29,8 +29,8 @@
     <None Include="README.md" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.4.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>packages\nanoFramework.CoreLibrary.1.10.4-preview.11\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.10.5.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>packages\nanoFramework.CoreLibrary.1.10.5-preview.18\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/devices/Uln2003/Uln2003.nuspec
+++ b/devices/Uln2003/Uln2003.nuspec
@@ -20,7 +20,7 @@
     <summary>Iot.Device.Uln2003 assembly for .NET nanoFramework C# projects</summary>
     <tags>nanoFramework C# csharp netmf netnf Iot.Device.Uln2003</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.4-preview.11" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.10.5-preview.18" />
       <dependency id="nanoFramework.Runtime.Events" version="1.9.0-preview.26" />
       <dependency id="nanoFramework.System.Device.Gpio" version="1.0.0-preview.40" />
       <dependency id="nanoFramework.System.Math" version="1.4.0-preview.7" />

--- a/devices/Uln2003/packages.config
+++ b/devices/Uln2003/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.4-preview.11" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.10.5-preview.18" targetFramework="netnanoframework10" />
   <package id="nanoFramework.Runtime.Events" version="1.9.0-preview.26" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Device.Gpio" version="1.0.0-preview.40" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Math" version="1.4.0-preview.7" targetFramework="netnanoframework10" />

--- a/devices/Uln2003/samples/Uln2003.Samples.nfproj
+++ b/devices/Uln2003/samples/Uln2003.Samples.nfproj
@@ -29,8 +29,8 @@
     <Content Include="Uln2003.png" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.4.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.4-preview.11\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.10.5.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5-preview.18\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/devices/Uln2003/samples/packages.config
+++ b/devices/Uln2003/samples/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.4-preview.11" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.10.5-preview.18" targetFramework="netnanoframework10" />
   <package id="nanoFramework.Runtime.Events" version="1.9.0-preview.26" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Device.Gpio" version="1.0.0-preview.40" targetFramework="netnanoframework10" />
 </packages>

--- a/devices/Vl53L0X/Vl53L0X.nfproj
+++ b/devices/Vl53L0X/Vl53L0X.nfproj
@@ -20,8 +20,8 @@
   </PropertyGroup>
   <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.props" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.props')" />
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.4.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>packages\nanoFramework.CoreLibrary.1.10.4-preview.11\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.10.5.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>packages\nanoFramework.CoreLibrary.1.10.5-preview.18\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/devices/Vl53L0X/packages.config
+++ b/devices/Vl53L0X/packages.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.4-preview.11" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.10.5-preview.18" targetFramework="netnanoframework10" />
   <package id="nanoFramework.Runtime.Events" version="1.9.0-preview.26" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Device.Gpio" version="1.0.0-preview.40" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Device.I2c" version="1.0.1-preview.33" targetFramework="netnanoframework10" />


### PR DESCRIPTION
## Description
- Fix references in several projects.
- Update packages and nuspec files accordingly. 

## Motivation and Context
- Several projects where using simplified reference declaration which doesn't work for nuget updates, thus have been left behind in the automatic updates.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
