### PR TITLE
Adjusting HCSR04 to be used with one pin

### DIFF
--- a/devices/Hcsr04/Hcsr04.nfproj
+++ b/devices/Hcsr04/Hcsr04.nfproj
@@ -23,12 +23,24 @@
       <HintPath>packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
     </Reference>
     <Reference Include="nanoFramework.Runtime.Events, Version=1.9.2.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>packages\nanoFramework.Runtime.Events.1.9.2-preview.5\lib\nanoFramework.Runtime.Events.dll</HintPath>
+      <HintPath>packages\nanoFramework.Runtime.Events.1.9.2-preview.8\lib\nanoFramework.Runtime.Events.dll</HintPath>
       <Private>True</Private>
+      <SpecificVersion>True</SpecificVersion>
     </Reference>
     <Reference Include="System.Device.Gpio, Version=1.0.2.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>packages\nanoFramework.System.Device.Gpio.1.0.2-preview.5\lib\System.Device.Gpio.dll</HintPath>
+      <HintPath>packages\nanoFramework.System.Device.Gpio.1.0.2-preview.7\lib\System.Device.Gpio.dll</HintPath>
       <Private>True</Private>
+      <SpecificVersion>True</SpecificVersion>
+    </Reference>
+    <Reference Include="System.Device.Model, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>packages\nanoFramework.System.Device.Model.1.0.176\lib\System.Device.Model.dll</HintPath>
+      <Private>True</Private>
+      <SpecificVersion>True</SpecificVersion>
+    </Reference>
+    <Reference Include="System.Diagnostics.Stopwatch, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>packages\nanoFramework.System.Diagnostics.Stopwatch.1.0.160\lib\System.Diagnostics.Stopwatch.dll</HintPath>
+      <Private>True</Private>
+      <SpecificVersion>True</SpecificVersion>
     </Reference>
     <Reference Include="UnitsNet.Length, Version=4.102.0.0, Culture=neutral, PublicKeyToken=null">
       <HintPath>packages\UnitsNet.nanoFramework.Length.4.102.0\lib\UnitsNet.Length.dll</HintPath>
@@ -44,8 +56,6 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <None Include="*.md" />
   </ItemGroup>
-  <Import Project="..\..\src\System.Device.Model\System.Device.Model.projitems" Label="Shared" />
-  <Import Project="..\..\src\Stopwatch\Stopwatch.projitems" Label="Shared" />
   <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.CSharp.targets" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.CSharp.targets')" />
   <ProjectExtensions>
     <ProjectCapabilities>

--- a/devices/Hcsr04/Hcsr04.nuspec
+++ b/devices/Hcsr04/Hcsr04.nuspec
@@ -24,6 +24,8 @@
       <dependency id="nanoFramework.System.Device.Gpio" version="1.0.2-preview.5" />
       <dependency id="nanoFramework.Runtime.Events" version="1.9.2-preview.5" />
       <dependency id="UnitsNet.nanoFramework.Length" version="4.102.0" />
+      <dependency id="nanoFramework.System.Device.Model" version="1.0.176" />
+      <dependency id="nanoFramework.System.Diagnostics.Stopwatch" version="1.0.160" />
     </dependencies>
   </metadata>
   <files>

--- a/devices/Hcsr04/Hcsr04.sln
+++ b/devices/Hcsr04/Hcsr04.sln
@@ -1,4 +1,3 @@
-
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.30413.136
@@ -7,17 +6,7 @@ Project("{11A8DD76-328B-46DF-9F39-F559912D0360}") = "Hcsr04", "Hcsr04.nfproj", "
 EndProject
 Project("{11A8DD76-328B-46DF-9F39-F559912D0360}") = "Hcsr04.Samples", "samples\Hcsr04.Samples.nfproj", "{6058FB06-7991-42A2-B1B5-796BD2B522D9}"
 EndProject
-Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "System.Device.Model", "..\..\src\System.Device.Model\System.Device.Model.shproj", "{23325B14-3651-4879-9697-9846FF123FEB}"
-EndProject
-Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "Stopwatch", "..\..\src\Stopwatch\Stopwatch.shproj", "{875D133B-033B-4D11-B1A2-DEF898349AD5}"
-EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Shared Projects", "Shared Projects", "{6123079C-0771-4550-8C30-7297B4A2D670}"
-EndProject
 Global
-	GlobalSection(SharedMSBuildProjectFiles) = preSolution
-		..\..\src\System.Device.Model\System.Device.Model.projitems*{23325b14-3651-4879-9697-9846ff123feb}*SharedItemsImports = 13
-		..\..\src\Stopwatch\Stopwatch.projitems*{875d133b-033b-4d11-b1a2-def898349ad5}*SharedItemsImports = 13
-	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
@@ -38,10 +27,6 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
-	EndGlobalSection
-	GlobalSection(NestedProjects) = preSolution
-		{23325B14-3651-4879-9697-9846FF123FEB} = {6123079C-0771-4550-8C30-7297B4A2D670}
-		{875D133B-033B-4D11-B1A2-DEF898349AD5} = {6123079C-0771-4550-8C30-7297B4A2D670}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {68B0B0FD-0E94-4FF3-BCB1-233F4FA2C017}

--- a/devices/Hcsr04/README.md
+++ b/devices/Hcsr04/README.md
@@ -8,6 +8,8 @@ Device bindings for the HC-SR04 sonar distance sensor. Calculates the distance f
 
 ## Usage
 
+In most of the cases, you just need to pass the 2 pins you're going to use: the Echo and Trigger pins.
+
 ```sharp
 using (var sonar = new Hcsr04(4, 17))
 {
@@ -23,6 +25,8 @@ using (var sonar = new Hcsr04(4, 17))
     Thread.Sleep(1000);
 }
 ```
+
+> Note: it is possible to use the same pin for both Trigger and Echo but it's not recommended.
 
 ### Hardware Required
 

--- a/devices/Hcsr04/packages.config
+++ b/devices/Hcsr04/packages.config
@@ -1,8 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.Runtime.Events" version="1.9.2-preview.5" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.System.Device.Gpio" version="1.0.2-preview.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.Runtime.Events" version="1.9.2-preview.8" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.System.Device.Gpio" version="1.0.2-preview.7" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.System.Device.Model" version="1.0.176" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.System.Diagnostics.Stopwatch" version="1.0.160" targetFramework="netnanoframework10" />
   <package id="Nerdbank.GitVersioning" version="3.4.194" developmentDependency="true" targetFramework="netnanoframework10" />
   <package id="UnitsNet.nanoFramework.Length" version="4.102.0" targetFramework="netnanoframework10" />
 </packages>

--- a/devices/Hcsr04/samples/Hcsr04.Samples.nfproj
+++ b/devices/Hcsr04/samples/Hcsr04.Samples.nfproj
@@ -25,12 +25,24 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="nanoFramework.Runtime.Events, Version=1.9.2.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.Runtime.Events.1.9.2-preview.5\lib\nanoFramework.Runtime.Events.dll</HintPath>
+      <HintPath>..\packages\nanoFramework.Runtime.Events.1.9.2-preview.8\lib\nanoFramework.Runtime.Events.dll</HintPath>
       <Private>True</Private>
+      <SpecificVersion>True</SpecificVersion>
     </Reference>
     <Reference Include="System.Device.Gpio, Version=1.0.2.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.System.Device.Gpio.1.0.2-preview.5\lib\System.Device.Gpio.dll</HintPath>
+      <HintPath>..\packages\nanoFramework.System.Device.Gpio.1.0.2-preview.7\lib\System.Device.Gpio.dll</HintPath>
       <Private>True</Private>
+      <SpecificVersion>True</SpecificVersion>
+    </Reference>
+    <Reference Include="System.Device.Model, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\nanoFramework.System.Device.Model.1.0.176\lib\System.Device.Model.dll</HintPath>
+      <Private>True</Private>
+      <SpecificVersion>True</SpecificVersion>
+    </Reference>
+    <Reference Include="System.Diagnostics.Stopwatch, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\nanoFramework.System.Diagnostics.Stopwatch.1.0.160\lib\System.Diagnostics.Stopwatch.dll</HintPath>
+      <Private>True</Private>
+      <SpecificVersion>True</SpecificVersion>
     </Reference>
     <Reference Include="UnitsNet.Length, Version=4.102.0.0, Culture=neutral, PublicKeyToken=null">
       <HintPath>..\packages\UnitsNet.nanoFramework.Length.4.102.0\lib\UnitsNet.Length.dll</HintPath>

--- a/devices/Hcsr04/samples/Program.cs
+++ b/devices/Hcsr04/samples/Program.cs
@@ -9,6 +9,7 @@ using UnitsNet;
 
 Debug.WriteLine("Hello Hcsr04 Sample!");
 
+// You can use as well the same pin: using Hcsr04 sonar = new(5, 5);
 using Hcsr04 sonar = new(12, 14);
 while (true)
 {

--- a/devices/Hcsr04/samples/packages.config
+++ b/devices/Hcsr04/samples/packages.config
@@ -1,7 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.Runtime.Events" version="1.9.2-preview.5" />
-  <package id="nanoFramework.System.Device.Gpio" version="1.0.2-preview.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.Runtime.Events" version="1.9.2-preview.8" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.System.Device.Gpio" version="1.0.2-preview.7" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.System.Device.Model" version="1.0.176" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.System.Diagnostics.Stopwatch" version="1.0.160" targetFramework="netnanoframework10" />
   <package id="UnitsNet.nanoFramework.Length" version="4.102.0" targetFramework="netnanoframework10" />
 </packages>


### PR DESCRIPTION
<!--- In the TITLE (above **NOT HERE**) provide a general, short summary of your changes -->
<!--- Please DO NOT use references to other PR's or issues -->

## Description
<!--- Describe your changes in detail -->
<!--- Bulleted list. Full sentences. Ending with a dot. -->
Adjusting HCSR04 to be used with one pin

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes/closes/resolves an open issue, please link to the issue here using the template bellow (mind the link as all issues are open in the Home repository, not in this one) -->
- Adjusting HCSR04 to be used with one pin
- Used in the MagicBit bot where the sensor is using only 1 pin

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On a real sensor

## Screenshots<!-- (if appropriate): -->
![image](https://user-images.githubusercontent.com/8145578/141819097-7752f9e6-28ac-4f0b-9c49-7e76dc4ecfdd.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
