### PR TITLE
Fixed max range for Hcsr04.ESP32

### DIFF
--- a/devices/Hcsr04.Esp32/Hcsr04.Esp32.cs
+++ b/devices/Hcsr04.Esp32/Hcsr04.Esp32.cs
@@ -120,7 +120,7 @@ namespace Iot.Device.Hcsr04.Esp32
             // Distance calculated as  (speed of sound) * duration(meters) / 2 
             result = Length.FromMeters(_speedOfSound * duration / (1000000 * 2));
 
-            if (result.Value > 0.4)
+            if (result.Value > 4)
             {
                 // result is more than sensor supports
                 // something went wrong


### PR DESCRIPTION
The max range of the sensor is 4m, not 0.4m.

## Description
As defined in the datasheet, the max range of the sensor is 4m.
The validation if the measurement is out of range has been corrected from 0.4 to 4.

## Motivation and Context
Without the fix, only measurements up to 40cm are measured. 
For higher distances, which are still in the valid range of the sensor, the library reports an invalid measurement.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
Tested with real device.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
