### PR TITLE
Fix dependencies for device WS28xx

### DIFF
--- a/devices/Ws28xx/Ws28xx.nfproj
+++ b/devices/Ws28xx/Ws28xx.nfproj
@@ -20,25 +20,19 @@
   </PropertyGroup>
   <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.props" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.props')" />
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>
-    <Reference Include="nanoFramework.Runtime.Events, Version=1.9.2.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>packages\nanoFramework.Runtime.Events.1.9.2-preview.8\lib\nanoFramework.Runtime.Events.dll</HintPath>
-      <Private>True</Private>
-      <SpecificVersion>True</SpecificVersion>
+    <Reference Include="nanoFramework.Runtime.Events">
+      <HintPath>packages\nanoFramework.Runtime.Events.1.9.2\lib\nanoFramework.Runtime.Events.dll</HintPath>
     </Reference>
-    <Reference Include="System.Device.Gpio, Version=1.0.2.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>packages\nanoFramework.System.Device.Gpio.1.0.2-preview.7\lib\System.Device.Gpio.dll</HintPath>
-      <Private>True</Private>
-      <SpecificVersion>True</SpecificVersion>
+    <Reference Include="System.Device.Gpio">
+      <HintPath>packages\nanoFramework.System.Device.Gpio.1.0.2\lib\System.Device.Gpio.dll</HintPath>
     </Reference>
-    <Reference Include="System.Device.Spi, Version=1.0.2.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>packages\nanoFramework.System.Device.Spi.1.0.2-preview.17\lib\System.Device.Spi.dll</HintPath>
-      <Private>True</Private>
-      <SpecificVersion>True</SpecificVersion>
+    <Reference Include="System.Device.Spi">
+      <HintPath>packages\nanoFramework.System.Device.Spi.1.0.2\lib\System.Device.Spi.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/devices/Ws28xx/Ws28xx.nuspec
+++ b/devices/Ws28xx/Ws28xx.nuspec
@@ -21,10 +21,10 @@
     <summary>Iot.Device.Ws28xx assembly for .NET nanoFramework C# projects</summary>
     <tags>nanoFramework C# csharp netmf netnf Iot.Device.Ws28xx</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
-      <dependency id="nanoFramework.Runtime.Events" version="1.9.2-preview.8" />
-      <dependency id="nanoFramework.System.Device.Spi" version="1.0.2-preview.17" />
-      <dependency id="nanoFramework.System.Device.Gpio" version="1.0.2-preview.7" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
+      <dependency id="nanoFramework.Runtime.Events" version="1.9.2" />
+      <dependency id="nanoFramework.System.Device.Spi" version="1.0.2" />
+      <dependency id="nanoFramework.System.Device.Gpio" version="1.0.2" />
     </dependencies>
   </metadata>
   <files>

--- a/devices/Ws28xx/packages.config
+++ b/devices/Ws28xx/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-	<package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
-	<package id="nanoFramework.Runtime.Events" version="1.9.2-preview.8" targetFramework="netnanoframework10" />
-	<package id="nanoFramework.System.Device.Gpio" version="1.0.2-preview.7" targetFramework="netnanoframework10" />
-	<package id="nanoFramework.System.Device.Spi" version="1.0.2-preview.17" targetFramework="netnanoframework10" />
-	<package id="Nerdbank.GitVersioning" version="3.4.240" developmentDependency="true" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.Runtime.Events" version="1.9.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.System.Device.Gpio" version="1.0.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.System.Device.Spi" version="1.0.2" targetFramework="netnanoframework10" />
+  <package id="Nerdbank.GitVersioning" version="3.4.240" developmentDependency="true" targetFramework="netnanoframework10" />
 </packages>

--- a/devices/Ws28xx/samples/Ws28xx.Samples.nfproj
+++ b/devices/Ws28xx/samples/Ws28xx.Samples.nfproj
@@ -21,25 +21,25 @@
   <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.props" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.props')" />
   <ItemGroup>
     <Reference Include="nanoFramework.Hardware.Esp32">
-      <HintPath>..\packages\nanoFramework.Hardware.Esp32.1.3.4-preview.11\lib\nanoFramework.Hardware.Esp32.dll</HintPath>
+      <HintPath>..\packages\nanoFramework.Hardware.Esp32.1.3.4\lib\nanoFramework.Hardware.Esp32.dll</HintPath>
     </Reference>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>
-    <Reference Include="nanoFramework.Runtime.Events, Version=1.9.2.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.Runtime.Events.1.9.2-preview.8\lib\nanoFramework.Runtime.Events.dll</HintPath>
+    <Reference Include="nanoFramework.Runtime.Events, Version=1.9.2.3, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.Runtime.Events.1.9.2\lib\nanoFramework.Runtime.Events.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>
-    <Reference Include="System.Device.Gpio, Version=1.0.2.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.System.Device.Gpio.1.0.2-preview.7\lib\System.Device.Gpio.dll</HintPath>
+    <Reference Include="System.Device.Gpio, Version=1.0.2.3, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.System.Device.Gpio.1.0.2\lib\System.Device.Gpio.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>
-    <Reference Include="System.Device.Spi, Version=1.0.2.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.System.Device.Spi.1.0.2-preview.17\lib\System.Device.Spi.dll</HintPath>
+    <Reference Include="System.Device.Spi, Version=1.0.2.3, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.System.Device.Spi.1.0.2\lib\System.Device.Spi.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/devices/Ws28xx/samples/packages.config
+++ b/devices/Ws28xx/samples/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.Hardware.Esp32" version="1.3.4-preview.11" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.Runtime.Events" version="1.9.2-preview.8" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.System.Device.Gpio" version="1.0.2-preview.7" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.System.Device.Spi" version="1.0.2-preview.17" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.Hardware.Esp32" version="1.3.4" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.Runtime.Events" version="1.9.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.System.Device.Gpio" version="1.0.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.System.Device.Spi" version="1.0.2" targetFramework="netnanoframework10" />
   <package id="Nerdbank.GitVersioning" version="3.4.240" targetFramework="netnanoframework10" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
## Description
Updated dependencies for device WS28xx so that there are not assembly mismatch when using the current mscorlib

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [X] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
