### PR TITLE
BinaryPrimitives: Fix ReadSingle*() in Release build

### DIFF
--- a/devices/System.Buffers.Binary.BinaryPrimitives/BinaryPrimitives.cs
+++ b/devices/System.Buffers.Binary.BinaryPrimitives/BinaryPrimitives.cs
@@ -226,7 +226,9 @@ namespace System.Buffers.Binary
                 *(IntPtr*)&flt = *(IntPtr*)&ieee754_bits; // https://stackoverflow.com/a/57532166/281337
             }
 
-            return flt;
+            // This assignment is required. Without it, the CLR will continue to use the ieee754_bits value (but only in Release builds).
+            float converted = flt;
+            return converted;
         }
 
         /// <summary>
@@ -249,7 +251,9 @@ namespace System.Buffers.Binary
                 *(IntPtr*)&flt = *(IntPtr*)&ieee754_bits; // https://stackoverflow.com/a/57532166/281337
             }
 
-            return flt;
+            // This assignment is required. Without it, the CLR will continue to use the ieee754_bits value (but only in Release builds).
+            float converted = flt;
+            return converted;
         }
 
         /// <summary>

--- a/tests/BinaryPrimitivesUnitTests/BinaryPrimitivesTests.cs
+++ b/tests/BinaryPrimitivesUnitTests/BinaryPrimitivesTests.cs
@@ -235,11 +235,13 @@ namespace BinaryPrimitivesUnitTests
             float floatValue = 3.141593f;
             byte[] floatValueInBe = new byte[] { 0x40, 0x49, 0x0F, 0xDC };
             float floatFromBytes;
+            double doubleFromBytes;
             float floatValueFromBitConverter;
             SpanByte floatToBytes = new byte[4];
 
             // Act
             floatFromBytes = BinaryPrimitives.ReadSingleBigEndian(floatValueInBe);
+            doubleFromBytes = BinaryPrimitives.ReadSingleBigEndian(floatValueInBe);
             BinaryPrimitives.WriteSingleBigEndian(floatToBytes, floatValue);
             floatValueFromBitConverter = BitConverter.IsLittleEndian ? BitConverter.ToSingle(new byte[] { floatValueInBe[3], floatValueInBe[2], floatValueInBe[1], floatValueInBe[0] }, 0) : BitConverter.ToSingle(floatValueInBe, 0);
 
@@ -250,6 +252,7 @@ namespace BinaryPrimitivesUnitTests
             Assert.Equal(floatValueInBe[3], floatToBytes[3]);
             Assert.Equal(floatValue, floatFromBytes);
             Assert.Equal(floatValue, floatValueFromBitConverter);
+            Assert.Equal(floatValue, doubleFromBytes, "This assert fails when the CLR didn't properly convert the uint into a float");
         }
 
         [TestMethod]
@@ -259,11 +262,13 @@ namespace BinaryPrimitivesUnitTests
             float floatValue = 3.141593f;
             byte[] floatValueInLe = new byte[] { 0xDC, 0x0F, 0x49, 0x40 };
             float floatFromBytes;
+            double doubleFromBytes;
             float floatValueFromBitConverter;
             SpanByte floatToBytes = new byte[4];
 
             // Act
             floatFromBytes = BinaryPrimitives.ReadSingleLittleEndian(floatValueInLe);
+            doubleFromBytes = BinaryPrimitives.ReadSingleLittleEndian(floatValueInLe);
             BinaryPrimitives.WriteSingleLittleEndian(floatToBytes, floatValue);
             floatValueFromBitConverter = BitConverter.IsLittleEndian ? BitConverter.ToSingle(floatValueInLe, 0) : BitConverter.ToSingle(new byte[] { floatValueInLe[3], floatValueInLe[2], floatValueInLe[1], floatValueInLe[0] }, 0);
 
@@ -274,6 +279,7 @@ namespace BinaryPrimitivesUnitTests
             Assert.Equal(floatValueInLe[3], floatToBytes[3]);
             Assert.Equal(floatValue, floatFromBytes);
             Assert.Equal(floatValue, floatValueFromBitConverter);
+            Assert.Equal(floatValue, doubleFromBytes, "This assert fails when the CLR didn't properly convert the uint into a float");
         }
     }
 }


### PR DESCRIPTION
## Description
* Add assignment to the correct type in ReadSingle*() methods
* Add test to capture this problem in the future

## Motivation and Context
Only in release builds, and also only when the result of the ReadSingle*() was not assigned to a float (but anything else, like double), the assigned value would be its underlying uint value.

A forced assignment in the ReadSingle*() functions fixes this problem for release builds. The test has been updated to capture this edge case.

The problem can be reproduced if you revert the changes in `BinaryPrimitives.cs` and then run the tests in Release mode.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
* Found and confirmed fixed in a practical application using the SPS30
* By updating the relevant testcases

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [x] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [x] I have added new tests to cover my changes.
