### PR TITLE
Update 5 NuGet dependencies

### DIFF
--- a/devices/Ft6xx6x/samples/Ft6xx6x.Samples.nfproj
+++ b/devices/Ft6xx6x/samples/Ft6xx6x.Samples.nfproj
@@ -59,8 +59,8 @@
       <HintPath>..\packages\nanoFramework.Hardware.Esp32.1.4.8\lib\nanoFramework.Hardware.Esp32.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nanoFramework.M5Core2, Version=1.1.78.31879, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\packages\nanoFramework.M5Core2.1.1.78\lib\nanoFramework.M5Core2.dll</HintPath>
+    <Reference Include="nanoFramework.M5Core2, Version=1.1.82.38397, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\nanoFramework.M5Core2.1.1.82\lib\nanoFramework.M5Core2.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nanoFramework.ResourceManager, Version=1.2.7.23963, Culture=neutral, PublicKeyToken=c07d481e9758c731">
@@ -137,20 +137,20 @@
       <HintPath>..\packages\nanoFramework.System.Threading.1.1.8\lib\System.Threading.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="UnitsNet.ElectricCurrent, Version=4.147.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\packages\UnitsNet.nanoFramework.ElectricCurrent.4.147.0\lib\UnitsNet.ElectricCurrent.dll</HintPath>
+    <Reference Include="UnitsNet.ElectricCurrent, Version=4.148.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\UnitsNet.nanoFramework.ElectricCurrent.4.148.0\lib\UnitsNet.ElectricCurrent.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="UnitsNet.ElectricPotential, Version=4.147.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\packages\UnitsNet.nanoFramework.ElectricPotential.4.147.0\lib\UnitsNet.ElectricPotential.dll</HintPath>
+    <Reference Include="UnitsNet.ElectricPotential, Version=4.148.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\UnitsNet.nanoFramework.ElectricPotential.4.148.0\lib\UnitsNet.ElectricPotential.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="UnitsNet.Power, Version=4.147.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\packages\UnitsNet.nanoFramework.Power.4.147.0\lib\UnitsNet.Power.dll</HintPath>
+    <Reference Include="UnitsNet.Power, Version=4.148.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\UnitsNet.nanoFramework.Power.4.148.0\lib\UnitsNet.Power.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="UnitsNet.Temperature, Version=4.147.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\packages\UnitsNet.nanoFramework.Temperature.4.147.0\lib\UnitsNet.Temperature.dll</HintPath>
+    <Reference Include="UnitsNet.Temperature, Version=4.148.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\UnitsNet.nanoFramework.Temperature.4.148.0\lib\UnitsNet.Temperature.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>

--- a/devices/Ft6xx6x/samples/packages.config
+++ b/devices/Ft6xx6x/samples/packages.config
@@ -10,7 +10,7 @@
   <package id="nanoFramework.Iot.Device.Ft6xx6x" version="1.2.141" targetFramework="netnano1.0" />
   <package id="nanoFramework.Iot.Device.Mpu6886" version="1.2.141" targetFramework="netnano1.0" />
   <package id="nanoFramework.Iot.Device.Rtc" version="1.2.141" targetFramework="netnano1.0" />
-  <package id="nanoFramework.M5Core2" version="1.1.78" targetFramework="netnano1.0" />
+  <package id="nanoFramework.M5Core2" version="1.1.82" targetFramework="netnano1.0" />
   <package id="nanoFramework.ResourceManager" version="1.2.7" targetFramework="netnano1.0" />
   <package id="nanoFramework.Runtime.Events" version="1.11.1" targetFramework="netnano1.0" />
   <package id="nanoFramework.Runtime.Native" version="1.5.4" targetFramework="netnano1.0" />
@@ -31,8 +31,8 @@
   <package id="nanoFramework.System.Numerics" version="1.2.144" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Text" version="1.2.22" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Threading" version="1.1.8" targetFramework="netnano1.0" />
-  <package id="UnitsNet.nanoFramework.ElectricCurrent" version="4.147.0" targetFramework="netnano1.0" />
-  <package id="UnitsNet.nanoFramework.ElectricPotential" version="4.147.0" targetFramework="netnano1.0" />
-  <package id="UnitsNet.nanoFramework.Power" version="4.147.0" targetFramework="netnano1.0" />
-  <package id="UnitsNet.nanoFramework.Temperature" version="4.147.0" targetFramework="netnano1.0" />
+  <package id="UnitsNet.nanoFramework.ElectricCurrent" version="4.148.0" targetFramework="netnano1.0" />
+  <package id="UnitsNet.nanoFramework.ElectricPotential" version="4.148.0" targetFramework="netnano1.0" />
+  <package id="UnitsNet.nanoFramework.Power" version="4.148.0" targetFramework="netnano1.0" />
+  <package id="UnitsNet.nanoFramework.Temperature" version="4.148.0" targetFramework="netnano1.0" />
 </packages>

--- a/devices/Ft6xx6x/samples/packages.lock.json
+++ b/devices/Ft6xx6x/samples/packages.lock.json
@@ -64,9 +64,9 @@
       },
       "nanoFramework.M5Core2": {
         "type": "Direct",
-        "requested": "[1.1.78, 1.1.78]",
-        "resolved": "1.1.78",
-        "contentHash": "2066tVT5uYH34SMBZRS2twDrQQMfGjmY1Tuj+I3kVgF29H3psdLMEiHZ2laeCPS2iuAh0AkildrQYC2+yzYp7A=="
+        "requested": "[1.1.82, 1.1.82]",
+        "resolved": "1.1.82",
+        "contentHash": "ngSo+OIKp5ZQK4BPFgQUQgr86nTGxIUjr84nivU0/QEC3MGy1cZYg6i409rk70l0wi3l+ebkGDD2Y4G/nAwM2Q=="
       },
       "nanoFramework.ResourceManager": {
         "type": "Direct",
@@ -190,27 +190,27 @@
       },
       "UnitsNet.nanoFramework.ElectricCurrent": {
         "type": "Direct",
-        "requested": "[4.147.0, 4.147.0]",
-        "resolved": "4.147.0",
-        "contentHash": "GG4UA1HYfsuFWufm5/JJY6IP6gFumV6s15aZNM9tpJJVpCTuVxzE+o1OwSneULctK8zWr/fxKq890EWdVvZaww=="
+        "requested": "[4.148.0, 4.148.0]",
+        "resolved": "4.148.0",
+        "contentHash": "MGYT1M+2v8qm1Ff9c5jQK2+Obt5sycyHRSjCN6YvyxqhWgZjoPhzEQ1ID6rRTiGbDEP0zDBMIr9gS974bFwFrA=="
       },
       "UnitsNet.nanoFramework.ElectricPotential": {
         "type": "Direct",
-        "requested": "[4.147.0, 4.147.0]",
-        "resolved": "4.147.0",
-        "contentHash": "+Bsh7FPh7Q+8sdf6Nz2MO6Qy2UGRUFT7f1PL8RPTcwjEMSopHlffgxG8fQEDrcwRqPrIwqctkEzPhDbtWhuT6g=="
+        "requested": "[4.148.0, 4.148.0]",
+        "resolved": "4.148.0",
+        "contentHash": "bGYRY/vD+e4zMK01yPYTk/Xc5NQID2UuM8AWaheOltuUrwyAFqDMJqL/d36GV3q5wcrRCMqLD+EBQbQ06bQgVQ=="
       },
       "UnitsNet.nanoFramework.Power": {
         "type": "Direct",
-        "requested": "[4.147.0, 4.147.0]",
-        "resolved": "4.147.0",
-        "contentHash": "UhXl/go9lAQGq2vqpAnqgqehoJzNwffmYg2wXGL6QtTc0vY9wGOzSxBwOnDU6KK1x18pttcgdN7NT1bKFcgOxA=="
+        "requested": "[4.148.0, 4.148.0]",
+        "resolved": "4.148.0",
+        "contentHash": "d/D0HuWRZDwIZrAtxCvnY8c4LuNcORELjEmItdntkKFHxvz4sIUZvFkC7+52lBQ1BKoC1JgOPGPDeIs+zyuJvA=="
       },
       "UnitsNet.nanoFramework.Temperature": {
         "type": "Direct",
-        "requested": "[4.147.0, 4.147.0]",
-        "resolved": "4.147.0",
-        "contentHash": "y7KgrrQz9Q+cGg1wY92YTgQIqUpdgzBM3rvIbHYqjooG0MDAj+07ERAKJ1sq+39P3nBmmzETHdfhIU1acocG8A=="
+        "requested": "[4.148.0, 4.148.0]",
+        "resolved": "4.148.0",
+        "contentHash": "Govk4JMC9t6ZgjPtEcE2lTQsK2COds8AK8I9Zm0wx1tpCk7XPglnPiq+ofDRrkLUCrMAfXxm9Cf3+/VqJXnW0Q=="
       }
     }
   }


### PR DESCRIPTION
Bumps nanoFramework.M5Core2 from 1.1.78 to 1.1.82</br>Bumps UnitsNet.nanoFramework.ElectricCurrent from 4.147.0 to 4.148.0</br>Bumps UnitsNet.nanoFramework.ElectricPotential from 4.147.0 to 4.148.0</br>Bumps UnitsNet.nanoFramework.Power from 4.147.0 to 4.148.0</br>Bumps UnitsNet.nanoFramework.Temperature from 4.147.0 to 4.148.0</br> [version update]

### :warning: This is an automated update. :warning:
