### PR TITLE
Fixed Axp192 battery status

### DIFF
--- a/devices/Axp192/BatteryStatus.cs
+++ b/devices/Axp192/BatteryStatus.cs
@@ -7,12 +7,15 @@ namespace Iot.Device.Axp192
 {
     /// <summary>
     /// The battery status.
+    /// <remarks>
+    /// <br>For more information see table REG01H, page 33 in datasheet</br>
+    /// </remarks>
     /// </summary>
     [Flags]
     public enum BatteryStatus
     {
-        /// <summary>Overwinered status.</summary>
-        Overwinered = 0b1000_000,
+        /// <summary>Overheating status.</summary>
+        Overheating = 0b1000_0000,
 
         /// <summary>Charging status.</summary>
         Charging = 0b0100_0000,


### PR DESCRIPTION
<!--- In the TITLE (↑↑↑↑ above ↑↑↑↑ **NOT HERE**) provide a general, short summary of your changes -->
<!--- Please DO NOT use references to other PR's or issues -->

## Description
- Added missing 0 to fix wrong BatteryStatus enum. 
- Added reference to where to find this enum in documentation.
- Changed name to provide clearer description of this status.
<!--- Describe your changes in detail -->
<!--- Bulleted list. Full sentences. Ending with a dot. -->

## Motivation and Context
While working with sample code for Axp192 on M5Stack Core2 I've noticed that there was a duplicate status enum. While working with translated documentation I've also noticed that more fitting name to this status would be "Overheating" rather than "Overwinered"

## Screenshots<!-- (IF APPROPRIATE): -->
Snippet from translated Axp192 documentation
![image](https://user-images.githubusercontent.com/24566138/211213081-8d0d3aac-1393-4c48-8f6f-d03bac499eb9.png)

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
