### PR TITLE
Mifare improvements (copy-paste from dotnet.iot repo)

### DIFF
--- a/devices/Card/Mifare/MifareCard.cs
+++ b/devices/Card/Mifare/MifareCard.cs
@@ -12,16 +12,21 @@ namespace Iot.Device.Card.Mifare
 {
     /// <summary>
     /// A Mifare card class
-    /// So far only supports the classical 1K cards
+    /// Supports Mifare Classic 1K and 4K
+    /// Also supports Mifare Plus 2K and 4K operating in SL1
     /// </summary>
     public class MifareCard
     {
+        private const byte BytesPerBlock = 16;
+        private const byte BlocksPerSmallSector = 4;
+        private const byte BlocksPerLargeSector = 16;
+        private const byte NumberOfSmallSectors = 32;
         private static readonly byte[] Mifare1KBlock1 = new byte[] { 0x14, 0x01, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1 };
         private static readonly byte[] Mifare1KBlock2 = new byte[] { 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1 };
         private static readonly byte[] Mifare1KBlock4 = new byte[] { 0x03, 0x00, 0xFE, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
-        private static readonly byte[] Mifare2KBlock64 = new byte[] { 0x14, 0x01, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1 };
+        private static readonly byte[] Mifare2KBlock64 = new byte[] { 0xBE, 0x01, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1 };
         private static readonly byte[] Mifare2KBlock66 = new byte[] { 0x00, 0x05, 0x00, 0x05, 0x00, 0x05, 0x00, 0x05, 0x00, 0x05, 0x00, 0x05, 0x00, 0x05, 0x00, 0x05 };
-        private static readonly byte[] Mifare4KBlock64 = new byte[] { 0x14, 0x01, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1 };
+        private static readonly byte[] Mifare4KBlock64 = new byte[] { 0xE8, 0x01, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1 };
         private static readonly byte[] StaticDefaultKeyA = new byte[6] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
         private static readonly byte[] StaticDefaultKeyB = new byte[6] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF };
         private static readonly byte[] StaticDefaultFirstBlockNdefKeyA = new byte[6] { 0xA0, 0xA1, 0xA2, 0xA3, 0xA4, 0xA5 };
@@ -45,15 +50,16 @@ namespace Iot.Device.Card.Mifare
         public static SpanByte DefaultKeyB => StaticDefaultKeyB;
 
         /// <summary>
-        /// Default first block Key A for NDEF card
+        /// Default Mifare Application Directory block Key A for NDEF card
+        /// The MAD is in the first sector on all cards and also sector 16 on 2K and 4K cards
         /// </summary>
-        /// <remarks>See https://www.nxp.com/docs/en/application-note/AN1304.pdf for more information</remarks>
+        /// <remarks>See https://www.nxp.com/docs/en/application-note/AN10787.pdf for more information</remarks>
         public static SpanByte DefaultFirstBlockNdefKeyA => StaticDefaultFirstBlockNdefKeyA;
 
         /// <summary>
         /// Default block Key A for NDEF card
         /// </summary>
-        /// <remarks>See https://www.nxp.com/docs/en/application-note/AN1304.pdf for more information</remarks>
+        /// <remarks>See https://www.nxp.com/docs/en/application-note/AN10787.pdf for more information</remarks>
         public static SpanByte DefaultBlocksNdefKeyA => StaticDefaultBlocksNdefKeyA;
 
         /// <summary>
@@ -97,6 +103,36 @@ namespace Iot.Device.Card.Mifare
         public byte[] Data { get; set; } = new byte[0];
 
         /// <summary>
+        /// Determine the block group corresponding to a block number
+        /// </summary>
+        /// <param name="blockNumber">block number</param>
+        /// <returns>block group</returns>
+        /// In a 1K card there are 16 sectors, each containing four blocks.
+        /// In a 2K card there are 32 sectors, each containing four blocks.
+        /// In a 4K card there are four blocks in the first 32 sectors and 16 blocks in the remaining sectors.
+        /// There are three groups of data blocks (either 1 or 5 blocks per group).
+        /// The last block in the sector is the sector trailer.
+        public static byte BlockNumberToBlockGroup(byte blockNumber) =>
+            (byte)((blockNumber < 128) ? (blockNumber % 4) : (blockNumber % 16) / 5);
+
+        /// <summary>
+        /// Determine the sector number corresponding to a particular block number
+        /// </summary>
+        /// <param name="blockNumber">block number</param>
+        /// <returns>sector number</returns>
+        public static byte BlockNumberToSector(byte blockNumber) =>
+            (byte)((blockNumber < 128) ? blockNumber / 4 : 32 + (blockNumber - 128) / 16);
+
+        /// <summary>
+        /// Determine the first block number of a specified sector and block group
+        /// </summary>
+        /// <param name="sector">sector number</param>
+        /// <param name="group">group (0 to 3, where 3 is the sector trailer)</param>
+        /// <returns>block number of the first (or only) block in the group</returns>
+        public static byte SectorToBlockNumber(byte sector, byte group = 0) =>
+            (byte)((sector < 32) ? sector * 4 + group : 128 + (sector - 32) * 16 + group * 5);
+
+        /// <summary>
         /// Constructor for Mifarecard
         /// </summary>
         /// <param name="rfid">A card transceiver class</param>
@@ -136,7 +172,7 @@ namespace Iot.Device.Card.Mifare
 
         #region Sector Tailer and Access Type
 
-        private Sixtet DecodeSectorTailer(byte blockNumber, byte[] sectorData)
+        private Sixtet DecodeSectorTailer(byte blockGroup, byte[] sectorData)
         {
             // Bit      7    6    5    4    3    2    1    0
             // Byte 6 !C23 !C22 !C21 !C20 !C13 !C12 !C11 !C10
@@ -144,14 +180,14 @@ namespace Iot.Device.Card.Mifare
             // Byte 8  C33  C32  C31  C30  C23  C22  C21  C20
             // Cab a = access bit and b = block number
             // Extract the C1
-            byte c1a = (byte)((~(sectorData[6]) >> blockNumber) & 0b0000_0001);
-            byte c1b = (byte)((sectorData[7] >> (4 + blockNumber)) & 0b0000_0001);
+            byte c1a = (byte)((~(sectorData[6]) >> blockGroup) & 0b0000_0001);
+            byte c1b = (byte)((sectorData[7] >> (4 + blockGroup)) & 0b0000_0001);
             // Extract the C2
-            byte c2a = (byte)((sectorData[8] >> blockNumber) & 0b0000_0001);
-            byte c2b = (byte)((~(sectorData[6]) >> (4 + blockNumber)) & 0b0000_0001);
+            byte c2a = (byte)((sectorData[8] >> blockGroup) & 0b0000_0001);
+            byte c2b = (byte)((~(sectorData[6]) >> (4 + blockGroup)) & 0b0000_0001);
             // Extract the C3
-            byte c3a = (byte)((~(sectorData[7]) >> blockNumber) & 0b0000_0001);
-            byte c3b = (byte)((sectorData[8] >> (4 + blockNumber)) & 0b0000_0001);
+            byte c3a = (byte)((~(sectorData[7]) >> blockGroup) & 0b0000_0001);
+            byte c3b = (byte)((sectorData[8] >> (4 + blockGroup)) & 0b0000_0001);
             return new Sixtet(c1a, c1b, c2a, c2b, c3a, c3b);
         }
 
@@ -248,7 +284,7 @@ namespace Iot.Device.Card.Mifare
         /// <returns>The encoded sector tailer for the specific block</returns>
         public Triplet EncodeSectorTailer(byte blockNumber, AccessType accessType)
         {
-            blockNumber = (byte)(blockNumber % 4);
+            byte blockGroup = BlockNumberToBlockGroup(blockNumber);
 
             byte c1 = 0;
             byte c2 = 0;
@@ -316,9 +352,9 @@ namespace Iot.Device.Card.Mifare
             }
 
             // Encore the access bits
-            byte b6 = (byte)((((~c2) & 0x01) << (4 + blockNumber)) | (((~c1) & 0x01) << blockNumber));
-            byte b7 = (byte)(((c1) << (4 + blockNumber)) | (((~c3) & 0x01) << blockNumber));
-            byte b8 = (byte)(((c3) << (4 + blockNumber)) | ((c2) << blockNumber));
+            byte b6 = (byte)((((~c2) & 0x01) << (4 + blockGroup)) | (((~c1) & 0x01) << blockGroup));
+            byte b7 = (byte)(((c1) << (4 + blockGroup)) | (((~c3) & 0x01) << blockGroup));
+            byte b8 = (byte)(((c3) << (4 + blockGroup)) | ((c2) << blockGroup));
             return new Triplet(b6, b7, b8);
         }
 
@@ -335,13 +371,13 @@ namespace Iot.Device.Card.Mifare
             // Byte 7  C13  C12  C11  C10 !C33 !C32 !C31 !C30
             // Byte 8  C33  C32  C31  C30  C23  C22  C21  C20
             // Cab a = access bit and b = block number
-            blockNumber = (byte)(blockNumber % 4);
-            if (blockNumber != 3)
+            byte blockGroup = BlockNumberToBlockGroup(blockNumber);
+            if (blockGroup != 3)
             {
                 return AccessSector.None;
             }
 
-            var sixtet = DecodeSectorTailer(blockNumber, sectorData);
+            var sixtet = DecodeSectorTailer(blockGroup, sectorData);
             if (sixtet.C1a != sixtet.C1b)
             {
                 return AccessSector.None;
@@ -422,13 +458,13 @@ namespace Iot.Device.Card.Mifare
             // Byte 7  C13  C12  C11  C10 !C33 !C32 !C31 !C30
             // Byte 8  C33  C32  C31  C30  C23  C22  C21  C20
             // Cab a = access bit and b = block number
-            blockNumber = (byte)(blockNumber % 4);
-            if (blockNumber == 3)
+            byte blockGroup = BlockNumberToBlockGroup(blockNumber);
+            if (blockGroup == 3)
             {
                 return AccessType.None;
             }
 
-            var sixtet = DecodeSectorTailer(blockNumber, sectorData);
+            var sixtet = DecodeSectorTailer(blockGroup, sectorData);
             if (sixtet.C1a != sixtet.C1b)
             {
                 return AccessType.None;
@@ -494,7 +530,18 @@ namespace Iot.Device.Card.Mifare
         /// <param name="accessSector">The access desired</param>
         /// <param name="accessTypes">An array of 3 AccessType determining access of each block</param>
         /// <returns>The 3 bytes encoding the rights</returns>
-        public Triplet EncodeSectorAndClockTailer(AccessSector accessSector, AccessType[] accessTypes)
+        /// This is a synonym of EncodeSectorAndBlockTailer (for backward compatibility)
+        [Obsolete("deprecated, use EncodeSectorAndBlockTailer instead")]
+        public Triplet EncodeSectorAndClockTailer(AccessSector accessSector, AccessType[] accessTypes) =>
+            EncodeSectorAndBlockTailer(accessSector, accessTypes);
+
+        /// <summary>
+        /// Encode the desired access for the full sector including the block tailer
+        /// </summary>
+        /// <param name="accessSector">The access desired</param>
+        /// <param name="accessTypes">An array of 3 AccessType determining access of each block</param>
+        /// <returns>The 3 bytes encoding the rights</returns>
+        public Triplet EncodeSectorAndBlockTailer(AccessSector accessSector, AccessType[] accessTypes)
         {
             if (accessTypes.Length != 3)
             {
@@ -523,27 +570,28 @@ namespace Iot.Device.Card.Mifare
         public Triplet EncodeDefaultSectorAndBlockTailer() => new Triplet(0xFF, 0x07, 0x80);
 
         /// <summary>
-        /// From the ATAQ ans SAK data find common card capacity
+        /// From the ATQA ans SAK data find common card capacity
         /// </summary>
-        /// <param name="ATAQ">The ATQA response</param>
+        /// <param name="ATQA">The ATQA response</param>
         /// <param name="SAK">The SAK response</param>
-        public void SetCapacity(ushort ATAQ, byte SAK)
+        /// <remarks>Does not recognize Mifare Plus cards, capacity must be set manually</remarks>
+        public void SetCapacity(ushort ATQA, byte SAK)
         {
             // Type of Mifare can be partially determined by ATQA and SAK
             // https://www.nxp.com/docs/en/application-note/AN10833.pdf
             // Not complete
-            if (ATAQ == 0x0004)
+            if (ATQA == 0x0004)
             {
                 if (SAK == 0x08)
                 {
                     Capacity = MifareCardCapacity.Mifare1K;
                 }
-                else if (SAK == 0x0009)
+                else if (SAK == 0x09)
                 {
                     Capacity = MifareCardCapacity.Mifare300;
                 }
             }
-            else if ((ATAQ == 0x0002) && (SAK == 0x18))
+            else if ((ATQA == 0x0002) && (SAK == 0x18))
             {
                 Capacity = MifareCardCapacity.Mifare4K;
             }
@@ -554,33 +602,14 @@ namespace Iot.Device.Card.Mifare
         /// </summary>
         /// <param name="blockNumber">Input block number</param>
         /// <returns>True if it is a sector block</returns>
-        public bool IsSectorBlock(byte blockNumber)
-        {
-            switch (Capacity)
-            {
-                default:
-                case MifareCardCapacity.Mifare300:
-                case MifareCardCapacity.Mifare1K:
-                case MifareCardCapacity.Mifare2K:
-                    return blockNumber % 4 == 3;
-                case MifareCardCapacity.Mifare4K:
-                    if (blockNumber < 128)
-                    {
-                        return blockNumber % 4 == 3;
-                    }
-                    else
-                    {
-                        return blockNumber % 16 == 15;
-                    }
-            }
-        }
+        public bool IsSectorBlock(byte blockNumber) => BlockNumberToBlockGroup(blockNumber) == 3;
 
         /// <summary>
         /// Get the number of blocks for a specific sector
         /// </summary>
         /// <param name="sectorNumber">Input sector number</param>
         /// <returns>The number of blocks for this specific sector</returns>
-        public byte GetNumberBlocks(byte sectorNumber) => sectorNumber < 32 ? (byte)4 : (byte)16;
+        public byte GetNumberBlocks(byte sectorNumber) => sectorNumber < 32 ? BlocksPerSmallSector : BlocksPerLargeSector;
 
         /// <summary>
         /// Get the number of blocks for a specific sector
@@ -721,7 +750,7 @@ namespace Iot.Device.Card.Mifare
                 Data = new byte[16];
             }
 
-            byte sectorTailer = (byte)(sector >= 32 ? 32 * 4 + (sector - 32) * 16 + 15 : sector * 4 + 3);
+            byte sectorTailer = SectorToBlockNumber(sector, 3);
             BlockNumber = sectorTailer;
             Command = authenticateWithKeyA ? MifareCardCommand.AuthenticationA : MifareCardCommand.AuthenticationB;
             var ret = RunMifareCardCommand();
@@ -760,7 +789,7 @@ namespace Iot.Device.Card.Mifare
                 return false;
             }
 
-            byte firstBlock = (byte)(sector >= 32 ? 32 * 4 + (sector - 32) * 16 : sector * 4);
+            byte firstBlock = SectorToBlockNumber(sector);
             // Authenticate to the rest of the blocks to format and format them
             for (byte block = firstBlock == 0 ? firstBlock++ : firstBlock; block < (firstBlock + nbBlocks - 1); block++)
             {
@@ -797,6 +826,7 @@ namespace Iot.Device.Card.Mifare
         /// </summary>
         /// <param name="keyB">The key B to be used for formatting, if empty, will use the default key B</param>
         /// <returns>True if success</returns>
+        /// <remarks>All sectors are configured as NFC Forum sectors</remarks>
         public bool FormatNdef(SpanByte keyB = default)
         {
             if (Capacity is not MifareCardCapacity.Mifare1K or MifareCardCapacity.Mifare2K or MifareCardCapacity.Mifare4K)
@@ -812,8 +842,12 @@ namespace Iot.Device.Card.Mifare
                 throw new ArgumentException($"{nameof(keyB)} can only be empty or 6 bytes length");
             }
 
-            // First write the data for the format
-            // All block data coming from https://www.nxp.com/docs/en/application-note/AN1304.pdf page 30+
+            // First write the Mifare Application Directory for the format
+            // All block data coming from https://www.nxp.com/docs/en/application-note/AN10787.pdf
+            byte[] madSectorTrailer = new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x78, 0x77, 0x88, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
+            DefaultFirstBlockNdefKeyA.CopyTo(madSectorTrailer);
+            madSectorTrailer[9] = Capacity == MifareCardCapacity.Mifare1K ? (byte)0xC1 : (byte)0xC2;
+            keyFormat.CopyTo(madSectorTrailer, 10);
             var authOk = AuthenticateBlockKeyB(keyFormat, 1);
             Data = Mifare1KBlock1;
             authOk &= WriteDataBlock(1);
@@ -821,13 +855,8 @@ namespace Iot.Device.Card.Mifare
             Data = Mifare1KBlock2;
             authOk &= WriteDataBlock(2);
             authOk &= AuthenticateBlockKeyB(keyFormat, 3);
-            Data = new byte[] { 0xA0, 0xA1, 0xA2, 0xA3, 0xA4, 0xA5, 0x78, 0x77, 088, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
-            Data[9] = Capacity == MifareCardCapacity.Mifare1K ? (byte)0xC1 : (byte)0xC2;
-            keyFormat.CopyTo(Data, 10);
+            Data = madSectorTrailer;
             authOk &= WriteDataBlock(3);
-            authOk &= AuthenticateBlockKeyB(keyFormat, 4);
-            Data = Mifare1KBlock4;
-            authOk &= WriteDataBlock(4);
 
             if (Capacity == MifareCardCapacity.Mifare2K)
             {
@@ -843,10 +872,10 @@ namespace Iot.Device.Card.Mifare
                 authOk &= AuthenticateBlockKeyB(keyFormat, block);
                 Data = Mifare2KBlock66;
                 authOk &= WriteDataBlock(block);
+                block++;
                 authOk &= AuthenticateBlockKeyB(keyFormat, block);
-                Data = new byte[] { 0xA0, 0xA1, 0xA2, 0xA3, 0xA4, 0xA5, 0x78, 0x77, 088, 0xC2, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
-                keyFormat.CopyTo(Data, 10);
-                authOk &= WriteDataBlock(3);
+                Data = madSectorTrailer;
+                authOk &= WriteDataBlock(block);
             }
             else if (Capacity == MifareCardCapacity.Mifare4K)
             {
@@ -862,32 +891,29 @@ namespace Iot.Device.Card.Mifare
                 authOk &= AuthenticateBlockKeyB(keyFormat, block);
                 Data = Mifare1KBlock2; // 66 is same as 2
                 authOk &= WriteDataBlock(block);
+                block++;
                 authOk &= AuthenticateBlockKeyB(keyFormat, block);
-                Data = new byte[] { 0xA0, 0xA1, 0xA2, 0xA3, 0xA4, 0xA5, 0x78, 0x77, 088, 0xC2, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
-                keyFormat.CopyTo(Data, 10);
-                authOk &= WriteDataBlock(3);
+                Data = madSectorTrailer;
+                authOk &= WriteDataBlock(block);
             }
 
+            // write the empty NDEF TLV in the first NFC sector
+            authOk &= AuthenticateBlockKeyB(keyFormat, 4);
+            Data = Mifare1KBlock4;
+            authOk &= WriteDataBlock(4);
+
             // GBP should be 0xC1 for the MAD sectors and 0x40 for the others for a full read/write access
-            for (int block = 4; block < nbBlocks; block++)
+            // We wrote the MAD sector trailers above, so we write the NFC sector trailers here
+            Data = new byte[] { 0, 0, 0, 0, 0, 0, 0x7F, 0x07, 0x88, 0x40, 0, 0, 0, 0, 0, 0 };
+            DefaultBlocksNdefKeyA.CopyTo(Data);
+            keyFormat.CopyTo(Data, 10);
+            for (byte sector = 1; sector < GetNumberSectors(); sector++)
             {
-                // Safe cast, max is 255
-                if ((IsSectorBlock((byte)block)) && (block != 67))
+                if (sector != 16)
                 {
-                    var ret = AuthenticateBlockKeyB(keyFormat, (byte)(block));
-                    authOk &= ret;
-                    if (ret)
-                    {
-                        BlockNumber = (byte)block;
-                        Command = MifareCardCommand.Write16Bytes;
-                        Data[6] = 0x7F;
-                        Data[7] = 0x07;
-                        Data[8] = 0x88;
-                        Data[9] = 0x40;
-                        StaticDefaultBlocksNdefKeyA.CopyTo(Data, 6);
-                        keyFormat.CopyTo(Data, 10);
-                        authOk &= WriteDataBlock((byte)block);
-                    }
+                    byte block = SectorToBlockNumber(sector, 3);
+                    authOk &= AuthenticateBlockKeyB(keyFormat, block);
+                    authOk &= WriteDataBlock(block);
                 }
             }
 
@@ -1011,8 +1037,9 @@ namespace Iot.Device.Card.Mifare
         /// <summary>
         /// Check if the card formated to NDEF
         /// </summary>
-        /// <returns>True if NDEF formated</returns>
+        /// <returns>True if NDEF formatted</returns>
         /// <remarks>It will only check the first 2 block of the first sector and that the GPB is set properly</remarks>
+        /// TODO: support formatted cards where some sectors are used for other purposes
         public bool IsFormattedNdef()
         {
             int nbBlocks = GetNumberBlocks();
@@ -1028,7 +1055,7 @@ namespace Iot.Device.Card.Mifare
             }
 
             // First write the data for the format
-            // All block data coming from https://www.nxp.com/docs/en/application-note/AN1304.pdf page 30+
+            // All block data coming from https://www.nxp.com/docs/en/application-note/AN10787.pdf
             var authOk = AuthenticateBlockKeyA(StaticDefaultFirstBlockNdefKeyA, 1);
             authOk &= ReadDataBlock(1);
             authOk &= Data.SequenceEqual(Mifare1KBlock1);
@@ -1262,9 +1289,14 @@ namespace Iot.Device.Card.Mifare
         private bool AuthenticateBlockKeyA(byte[] keyA, byte block)
         {
             byte[] oldKeyA = new byte[6];
-            if (KeyA is not object or { Length: not 6 })
+            if (KeyA is not object)
             {
                 KeyA = new byte[6];
+            }
+
+            if (KeyA.Length != 6)
+            {
+                throw new ArgumentException("Key A can only be 6 bytes");
             }
 
             KeyA.CopyTo(oldKeyA, 0);

--- a/devices/Card/Ultralight/UltralightCard.cs
+++ b/devices/Card/Ultralight/UltralightCard.cs
@@ -81,7 +81,7 @@ namespace Iot.Device.Card.Ultralight
         /// <param name="ATQA">The ATQA</param>
         /// <param name="SAK">The SAK</param>
         /// <returns>True if this is an Ultralight</returns>
-        public static bool IsUltralightCard(ushort ATQA, byte SAK) => (ATQA == 0x4400) && (SAK == 0);
+        public static bool IsUltralightCard(ushort ATQA, byte SAK) => (ATQA == 0x0044) && (SAK == 0);
 
         /// <summary>
         /// Constructor for Ultralight
@@ -444,7 +444,6 @@ namespace Iot.Device.Card.Ultralight
         /// </summary>
         public int NumberBlocks => UltralightCardType switch
         {
-            // Whenever NdefCapacity + 9 is used, then it's a guess
             UltralightCardType.UltralightNtag210 => 16,
             UltralightCardType.UltralightNtag212 => 45,
             UltralightCardType.UltralightNtag213 => 45,
@@ -452,10 +451,10 @@ namespace Iot.Device.Card.Ultralight
             UltralightCardType.UltralightNtag215 => 135,
             UltralightCardType.UltralightNtag216 => 231,
             UltralightCardType.UltralightNtag216F => 231,
-            UltralightCardType.UltralightEV1MF0UL1101 => 16,
-            UltralightCardType.UltralightEV1MF0ULH1101 => 41,
+            UltralightCardType.UltralightEV1MF0UL1101 => 20,
+            UltralightCardType.UltralightEV1MF0ULH1101 => 20,
             UltralightCardType.UltralightEV1MF0UL2101 => 41,
-            UltralightCardType.UltralightEV1MF0ULH2101 => NdefCapacity / 4 + 9,
+            UltralightCardType.UltralightEV1MF0ULH2101 => 41,
             UltralightCardType.UltralightNtagI2cNT3H1101 => 231,
             UltralightCardType.UltralightNtagI2cNT3H1101W0 => 231,
             UltralightCardType.UltralightNtagI2cNT3H2111W0 => 476 + 9,

--- a/devices/Card/Ultralight/UltralightCard.cs
+++ b/devices/Card/Ultralight/UltralightCard.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Buffers.Binary;
 using Iot.Device.Ndef;
 #if DEBUG
 using Microsoft.Extensions.Logging;
@@ -756,7 +757,27 @@ namespace Iot.Device.Card.Ultralight
                 return -1;
             }
 
-            return Data![0] + Data[1] << 8 + Data[2] << 16;
+            return Data![0] + (Data[1] << 8) + (Data[2] << 16);
+        }
+
+        /// <summary>
+        /// Increase a counter by a specified amount
+        /// </summary>
+        /// <param name="counter">A valid counter value, can vary depending on the card. 0xFF will ignore the value and use the one set in Counter</param>
+        /// <param name="increment">The amount to increment the counter. If negative, it will use the value of Data</param>
+        /// <returns>True if success</returns>
+        public bool IncreaseCounter(byte counter = 0xFF, int increment = -1)
+        {
+            Command = UltralightCommand.IncreaseCounter;
+            Counter = counter != 0xFF ? counter : Counter;
+            if (increment >= 0)
+            {
+                Data = new byte[4];
+                BinaryPrimitives.WriteInt32LittleEndian(Data, increment);
+            }
+
+            var ret = RunUltralightCommand();
+            return ret >= 0;
         }
 
         /// <summary>
@@ -969,6 +990,17 @@ namespace Iot.Device.Card.Ultralight
                     break;
                 case UltralightCommand.ReadCounter:
                     ser = new byte[2] { (byte)Command, Counter };
+                    break;
+                case UltralightCommand.IncreaseCounter:
+                    if (Data is null)
+                    {
+                        throw new ArgumentException($"Card is not configured for counter increase.");
+                    }
+
+                    ser = new byte[6];
+                    ser[0] = (byte)Command;
+                    ser[1] = Counter;
+                    Array.Copy(Data, 0, ser, 2, 3);    // 24-bit increment, fourth byte ignored
                     break;
                 case UltralightCommand.PasswordAuthentication:
                     if (AuthenticationKey is null or { Length: not 4 })

--- a/devices/Mfrc522/Mfrc522.cs
+++ b/devices/Mfrc522/Mfrc522.cs
@@ -273,7 +273,7 @@ namespace Iot.Device.Mfrc522
             }
             while (true);
 
-            card.Atqa = BinaryPrimitives.ReadUInt16BigEndian(atqa);
+            card.Atqa = BinaryPrimitives.ReadUInt16LittleEndian(atqa);
             var status = Select(out byte[]? nfcId, out byte sak);
             if (status != Status.Ok)
             {

--- a/devices/Mfrc522/Mfrc522.cs
+++ b/devices/Mfrc522/Mfrc522.cs
@@ -876,6 +876,8 @@ namespace Iot.Device.Mfrc522
             // Use built in functions for authentication in case of classic Mifare cards
             if ((dataToSend[0] == (byte)MifareCardCommand.AuthenticationA) || (dataToSend[0] == (byte)MifareCardCommand.AuthenticationB))
             {
+                // UltralightCommand.GetVersion has the same command code as MifareCardCommand.AuthenticationA
+                // GetVersion returns data; AuthenticationA does not
                 if (dataFromCard.Length == 0)
                 {
                     status = SendAndReceiveData(MfrcCommand.MifareAuthenticate, dataToSend.ToArray(), null);
@@ -883,15 +885,14 @@ namespace Iot.Device.Mfrc522
                 else
                 {
                     return SendWithCrc(dataToSend, dataFromCard);
-
                 }
 
                 return status == Status.Ok ? 0 : -1;
             }
             else if ((dataToSend[0] == (byte)MifareCardCommand.Incrementation) || (dataToSend[0] == (byte)MifareCardCommand.Decrementation)
-                || (dataToSend[0] == (byte)MifareCardCommand.Restore))
+                || (dataToSend[0] == (byte)MifareCardCommand.Restore) || (dataToSend[0] == (byte)MifareCardCommand.Write16Bytes))
             {
-                return TwoStepsIncDecRestore(dataToSend, dataFromCard);
+                return TwoStepsWrite16IncDecRestore(dataToSend);
             }
             else if (Helper.IsDefined((UltralightCommand)dataToSend[0]))
             {
@@ -953,7 +954,7 @@ namespace Iot.Device.Mfrc522
             return 0;
         }
 
-        private int TwoStepsIncDecRestore(SpanByte dataToSend, SpanByte dataFromCard)
+        private int TwoStepsWrite16IncDecRestore(SpanByte dataToSend)
         {
             Status status;
             SpanByte toSendFirst = new byte[4];
@@ -964,18 +965,19 @@ namespace Iot.Device.Mfrc522
             if (status != Status.Ok)
             {
 #if DEBUG
-                _logger.LogWarning($"{nameof(TwoStepsIncDecRestore)} - Error {(MfrcCommand)dataToSend[0]}");
+                _logger.LogWarning($"{nameof(TwoStepsWrite16IncDecRestore)} - Error {(MfrcCommand)dataToSend[0]}");
 #endif
                 return -1;
             }
 
             SpanByte toSendSecond = new byte[dataToSend.Length];
+            int dataLength = toSendSecond.Length - 2;
             dataToSend.Slice(2).CopyTo(toSendSecond);
-            CalculateCrc(toSendSecond.Slice(0, 2), toSendSecond.Slice(2, 2));
+            CalculateCrc(toSendSecond.Slice(0, dataLength), toSendSecond.Slice(dataLength, 2));
 
-            status = SendAndReceiveData(MfrcCommand.Transceive, toSendSecond.ToArray(), dataFromCard);
+            status = SendAndReceiveData(MfrcCommand.Transceive, toSendSecond.ToArray(), SpanByte.Empty);
 
-            return status == Status.Ok ? dataFromCard.Length : -1;
+            return status == Status.Ok ? 0 : -1;
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
<!--- In the TITLE (↑↑↑↑ above ↑↑↑↑ **NOT HERE**) provide a general, short summary of your changes -->
<!--- Please DO NOT use references to other PR's or issues -->

## Description
<!--- Describe your changes in detail -->
<!--- Bulleted list. Full sentences. Ending with a dot. -->

Transferred fixes and improvements from the [dotnet.iot](https://github.com/dotnet/iot) repository related to MIFARE cards.
- PR#2028 The pre-existing code assumed that there were always 4 blocks per sector and the sector trailer was always the fourth one. To handle larger sectors, this change introduces the concept of a "block group" within a sector, which represents the blocks that are associated with the access conditions. There are four block groups per sector. For sectors less than 32 there is one block per group. For sectors above 32, there are five data blocks per group; the last group is the sector trailer.
&emsp; Convenience methods to convert between block numbers and block groups were added, and they replace previously hardcoded calculations (such as blockNumber % 4) that are only correct for the first 32 blocks.
&emsp; The FormatNdef method formats the entire card for tags according to the NDEF specification. In general, the blocks on a Mifare Classic card may be assigned to multiple applications. The assignment is indicated by the Mifare Application Directory, which resides in sector 0 in all cards and also in sector 16 for cards larger than 1K. The previous code wasn't writing sector 16 correctly, and it wasn't using the correct checksum for the Mifare Application Directory in sector 16.
&emsp; In addition, there are some miscellaneous fixes.
&emsp; EncodeSectorAndClockTailer was an unfortunate misspelling. It is renamed to EncodeSectorAndBlockTailer, but for backward compatibility there is now a method with the old name that simply calls the new one.
&emsp;Renamed the name of the first parameter of SetCapacity from ATAQ to ATQA.
&emsp; Changed AuthenticateBlockKeyA to treat KeyA in the same way that AuthenticateBlockKeyB treats KeyB.
- PR#2027 Mifare's Write16Bytes command, which is used by Mifare Classic and Mifare Ultralight (where it is called "compatibility write") requires two writes to the card. The first one transfers the block number, and the second contains the data to be written. The Mfrc522 transceiver was not doing this, so writes to a Mifare Classic card always failed. Changed the Transceive function to treat Write16Bytes the same as counter increment, decrement, and restore (which also require two writes to the card).
- PR#2026 Add serialization for UltralightCommand.IncreaseCounter (which previously threw NotImplementedException).
&emsp; Add a new public function IncreaseCounter, corresponding to GetCounter
&emsp; Fix an operator precedence error in GetCounter
- PR#2022 The ATQA returned by NFC anticollision is converted by a ushort by the Mfrc522, Pn532, and Pn5180 transceivers. However, perhaps because the ATQA ushorts were inconsistently calculated by the different transceivers, it is also inconsistently used. Iot.Device.Card.Mifare.SetCapacity expects the ATQA of a Mifare classic 1K card to be 0x0004 and the ATQA of a Mifare classic 4K card to be 0x0002 (which are the values defined by NXP for those parts). However, Iot.Device.Card.Ultralight.UltralightCard.IsUltralightCard expects the ATQA of an Ultralight card to be 0x4400, when it should be 0x0044 according to the NXP spec.
&emsp; In addition, the property UltralightCard.NumberBlocks returns the number of blocks based upon the type of the card. The values returned for UltralightEV1 cards are incorrect. This causes the sample code to attempt to read past the end of the card prevents the card configuration from being decoded.
&emsp; This change aligns the expected ATQA and the actual number of blocks with the spec.
&emsp; Tested with an Mfrc522 and a Pn532 using Mifare Classic and Ultralight cards. The cards are now correctly identified.
- PR#2005 The two bytes of the ATQA need to be treated as a little-endian integer. https://github.com/AlexanderMaleckij/nanoFramework.IoT.Device/blob/1b43fec6ca02a51419b352c4c18ff9aa63fc46e0/devices/Mfrc522/Mfrc522.cs#L276

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If this **fixes** OR **closes** OR  **resolves** an open issue, please link to the issue there using the template bellow (mind the pattern to link there as all issues are tracked in the Home repository) -->
<!--- **JUST** replace NNNNN with the issue number -->
- Fixes nanoFramework/Home#1226

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
MFRC522 write functionality has been tested (see screenshots section).
Changes in the `UltralightCard` class have not been tested due to the lack of a card of this type.
Code in the modified files almost matches the code from the [dotnet.iot](https://github.com/dotnet/iot) repository in which it was tested.

## Screenshots<!-- (IF APPROPRIATE): -->
<kbd>
  <img src="https://user-images.githubusercontent.com/52193641/219870986-0ea821da-03c5-4884-ba8e-410d0e660fa1.png">
</kbd>

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [x] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
