### PR TITLE
[Dac63004] Fix buffer order in I2C commands

### DIFF
--- a/devices/Dac63004/Dac63004.cs
+++ b/devices/Dac63004/Dac63004.cs
@@ -145,7 +145,8 @@ namespace Iot.Device.Dac63004
             Register registerAddress = DacVoutConfigFromChannel(channel);
             var currentConfig = ReadFromRegister(registerAddress, 2);
 
-            currentConfig[1] &= (byte)gain;
+            // MSB 1st
+            currentConfig[0] &= (byte)gain;
 
             WriteToRegister(registerAddress, currentConfig);
         }
@@ -173,9 +174,9 @@ namespace Iot.Device.Dac63004
             // Data are in straight-binary format. MSB left-aligned.
             var data = value << 4;
 
-            // split and fill buffer
-            buffer[1] = (byte)(data >> 8);
-            buffer[0] = (byte)(data & 0xFF);
+            // split and fill buffer (MSB 1st)
+            buffer[0] = (byte)(data >> 8);
+            buffer[1] = (byte)data;
 
             WriteToRegister(registerAddress, buffer);
         }


### PR DESCRIPTION
## Description
- Fix buffer order in I2C commands.

## Motivation and Context
- Some operations were setting MSB and LSB in the wrong positions.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
