### PR TITLE
[Ws28xx.Esp32] Change visibility of several classes and properties

### DIFF
--- a/devices/Ws28xx.Esp32/BitmapImageNeo3.cs
+++ b/devices/Ws28xx.Esp32/BitmapImageNeo3.cs
@@ -10,7 +10,7 @@ namespace Iot.Device.Ws28xx.Esp32
     /// Special 24bit RGB format for Neo pixel LEDs where each bit is converted to 3 bits.
     /// A one is converted to 110, a zero is converted to 100.
     /// </summary>
-    internal class BitmapImageNeo3 : BitmapImage
+    public class BitmapImageNeo3 : BitmapImage
     {
         protected const int BytesPerComponent = 3;
         protected const int BytesPerPixel = BytesPerComponent * 3;

--- a/devices/Ws28xx.Esp32/BitmapImageNeo3.cs
+++ b/devices/Ws28xx.Esp32/BitmapImageNeo3.cs
@@ -12,7 +12,14 @@ namespace Iot.Device.Ws28xx.Esp32
     /// </summary>
     public class BitmapImageNeo3 : BitmapImage
     {
+        /// <summary>
+        /// The number of bytes per component.
+        /// </summary>
         protected const int BytesPerComponent = 3;
+
+        /// <summary>
+        /// The number of bytes per pixel.
+        /// </summary>
         protected const int BytesPerPixel = BytesPerComponent * 3;
 
         static BitmapImageNeo3()
@@ -31,11 +38,17 @@ namespace Iot.Device.Ws28xx.Esp32
             }
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BitmapImageNeo3"/> class.
+        /// </summary>
+        /// <param name="width">Width of the image.</param>
+        /// <param name="height">Height of the image.</param>
         public BitmapImageNeo3(int width, int height)
             : base(new byte[width * height * BytesPerPixel], width, height, width * BytesPerPixel)
         {
         }
 
+        /// <inheritdoc />
         public override void SetPixel(int x, int y, Color c)
         {
             var offset = (y * Stride) + (x * BytesPerPixel);
@@ -50,17 +63,20 @@ namespace Iot.Device.Ws28xx.Esp32
             Data[offset++] = Lookup[(c.B * BytesPerComponent) + 2];
         }
 
+        /// <inheritdoc />
         public override void Clear(int x, int y)
         {
             var offset = (y * Stride) + (x * BytesPerPixel);
             Array.Clear(Data, offset, 9);
         }
 
+        /// <inheritdoc />
         public override void Clear()
         {
             Array.Clear(Data, 0, Data.Length);
         }
 
+        /// <inheritdoc />
         public override void SetPixel(int x, int y, byte r, byte g, byte b)
         {
             var offset = (y * Stride) + (x * BytesPerPixel);
@@ -75,6 +91,9 @@ namespace Iot.Device.Ws28xx.Esp32
             Data[offset++] = Lookup[(b * BytesPerComponent) + 2];
         }
 
+        /// <summary>
+        /// Lookup table for color conversion.
+        /// </summary>
         protected static readonly byte[] Lookup = new byte[256 * BytesPerComponent];
     }
 }

--- a/devices/Ws28xx.Esp32/BitmapImageNeo3RGB.cs
+++ b/devices/Ws28xx.Esp32/BitmapImageNeo3RGB.cs
@@ -10,7 +10,7 @@ namespace Iot.Device.Ws28xx.Esp32
     /// A one is converted to 110, a zero is converted to 100.
     /// </summary>
     /// <seealso cref="Iot.Device.Ws28xx.BitmapImageNeo3" />
-    internal class BitmapImageNeo3Rgb : BitmapImageNeo3
+    public class BitmapImageNeo3Rgb : BitmapImageNeo3
     {
         public BitmapImageNeo3Rgb(int width, int height)
             : base(width, height)

--- a/devices/Ws28xx.Esp32/BitmapImageNeo3RGB.cs
+++ b/devices/Ws28xx.Esp32/BitmapImageNeo3RGB.cs
@@ -12,11 +12,17 @@ namespace Iot.Device.Ws28xx.Esp32
     /// <seealso cref="Iot.Device.Ws28xx.BitmapImageNeo3" />
     public class BitmapImageNeo3Rgb : BitmapImageNeo3
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BitmapImageNeo3Rgb"/> class.
+        /// </summary>
+        /// <param name="width">Width of the image.</param>
+        /// <param name="height">Height of the image.</param>
         public BitmapImageNeo3Rgb(int width, int height)
             : base(width, height)
         {
         }
 
+        /// <inheritdoc />
         public override void SetPixel(int x, int y, Color c)
         {
             var offset = (y * Stride) + (x * BytesPerPixel);

--- a/devices/Ws28xx.Esp32/BitmapImageNeo4.cs
+++ b/devices/Ws28xx.Esp32/BitmapImageNeo4.cs
@@ -5,9 +5,19 @@ using System.Drawing;
 
 namespace Iot.Device.Ws28xx.Esp32
 {
+    /// <summary>
+    /// BitmapImage Neo4
+    /// </summary>
     public class BitmapImageNeo4 : BitmapImage
     {
+        /// <summary>
+        /// The number of bytes per component.
+        /// </summary>
         private const int BytesPerComponent = 3;
+
+        /// <summary>
+        /// The number of bytes per pixel.
+        /// </summary>
         private const int BytesPerPixel = BytesPerComponent * 4;
 
         // This field defines the count within the lookup table. The length correlates to the possible values of a single byte.
@@ -20,11 +30,17 @@ namespace Iot.Device.Ws28xx.Esp32
             ClearInternal();
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BitmapImageNeo4"/> class.
+        /// </summary>
+        /// <param name="width">Width of the image.</param>
+        /// <param name="height">Height of the image.</param>
         public BitmapImageNeo4(int width, int height)
                             : base(new byte[width * height * BytesPerPixel], width, height, width * BytesPerPixel)
         {
         }
 
+        /// <inheritdoc />
         public override void Clear() => ClearInternal();
 
         private static void ClearInternal()
@@ -43,8 +59,10 @@ namespace Iot.Device.Ws28xx.Esp32
             }
         }
 
+        /// <inheritdoc />
         public override void Clear(int x, int y) => SetPixel(x, y, Color.Black);
 
+        /// <inheritdoc />
         public override void SetPixel(int x, int y, Color c)
         {
             // Alpha is used as white.
@@ -63,6 +81,7 @@ namespace Iot.Device.Ws28xx.Esp32
             Data[offset++] = Lookup[(c.A * BytesPerComponent) + 2];
         }
 
+        /// <inheritdoc />
         public override void SetPixel(int x, int y, byte r, byte g, byte b) => SetPixel(x, y, Color.FromArgb(r, g, b));
     }
 }

--- a/devices/Ws28xx.Esp32/BitmapImageNeo4.cs
+++ b/devices/Ws28xx.Esp32/BitmapImageNeo4.cs
@@ -5,7 +5,7 @@ using System.Drawing;
 
 namespace Iot.Device.Ws28xx.Esp32
 {
-    internal class BitmapImageNeo4 : BitmapImage
+    public class BitmapImageNeo4 : BitmapImage
     {
         private const int BytesPerComponent = 3;
         private const int BytesPerPixel = BytesPerComponent * 4;

--- a/devices/Ws28xx.Esp32/BitmapImageNeo4.cs
+++ b/devices/Ws28xx.Esp32/BitmapImageNeo4.cs
@@ -6,7 +6,7 @@ using System.Drawing;
 namespace Iot.Device.Ws28xx.Esp32
 {
     /// <summary>
-    /// BitmapImage Neo4
+    /// BitmapImage Neo4.
     /// </summary>
     public class BitmapImageNeo4 : BitmapImage
     {

--- a/devices/Ws28xx.Esp32/BitmapImageWs2808.cs
+++ b/devices/Ws28xx.Esp32/BitmapImageWs2808.cs
@@ -7,7 +7,7 @@ using System.Drawing;
 namespace Iot.Device.Ws28xx.Esp32
 {
     /// <summary>
-    /// BitmapImage Ws2808
+    /// BitmapImage Ws2808.
     /// </summary>
     public class BitmapImageWs2808 : BitmapImage
     {

--- a/devices/Ws28xx.Esp32/BitmapImageWs2808.cs
+++ b/devices/Ws28xx.Esp32/BitmapImageWs2808.cs
@@ -6,7 +6,7 @@ using System.Drawing;
 
 namespace Iot.Device.Ws28xx.Esp32
 {
-    internal class BitmapImageWs2808 : BitmapImage
+    public class BitmapImageWs2808 : BitmapImage
     {
         private const int BytesPerPixel = 3;
 

--- a/devices/Ws28xx.Esp32/BitmapImageWs2808.cs
+++ b/devices/Ws28xx.Esp32/BitmapImageWs2808.cs
@@ -6,15 +6,24 @@ using System.Drawing;
 
 namespace Iot.Device.Ws28xx.Esp32
 {
+    /// <summary>
+    /// BitmapImage Ws2808
+    /// </summary>
     public class BitmapImageWs2808 : BitmapImage
     {
         private const int BytesPerPixel = 3;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BitmapImageWs2808"/> class.
+        /// </summary>
+        /// <param name="width">Width of the image.</param>
+        /// <param name="height">Height of the image.</param>
         public BitmapImageWs2808(int width, int height)
             : base(new byte[width * height * BytesPerPixel], width, height, width * BytesPerPixel)
         {
         }
 
+        /// <inheritdoc />
         public override void SetPixel(int x, int y, Color c)
         {
             var offset = (y * Stride) + (x * BytesPerPixel);
@@ -23,6 +32,7 @@ namespace Iot.Device.Ws28xx.Esp32
             Data[offset++] = c.B;
         }
 
+        /// <inheritdoc />
         public override void SetPixel(int x, int y, byte r, byte g, byte b)
         {
             var offset = (y * Stride) + (x * BytesPerPixel);
@@ -37,6 +47,7 @@ namespace Iot.Device.Ws28xx.Esp32
             Array.Clear(Data, 0, Data.Length);
         }
 
+        /// <inheritdoc />
         public override void Clear(int x, int y)
         {
             var offset = (y * Stride) + (x * BytesPerPixel);

--- a/devices/Ws28xx.Esp32/BitmapImageWs2808GRB.cs
+++ b/devices/Ws28xx.Esp32/BitmapImageWs2808GRB.cs
@@ -6,15 +6,24 @@ using System.Drawing;
 
 namespace Iot.Device.Ws28xx.Esp32
 {
+    /// <summary>
+    /// BitmapImage Ws2808 GRB
+    /// </summary>
     public class BitmapImageWs2808Grb : BitmapImage
     {
         private const int BytesPerPixel = 3;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BitmapImageWs2808Grb"/> class.
+        /// </summary>
+        /// <param name="width">Width of the image.</param>
+        /// <param name="height">Height of the image.</param>
         public BitmapImageWs2808Grb(int width, int height)
             : base(new byte[width * height * BytesPerPixel], width, height, width * BytesPerPixel)
         {
         }
 
+        /// <inheritdoc />
         public override void SetPixel(int x, int y, Color c)
         {
             var offset = (y * Stride) + (x * BytesPerPixel);
@@ -23,6 +32,7 @@ namespace Iot.Device.Ws28xx.Esp32
             Data[offset++] = c.B;
         }
 
+        /// <inheritdoc />
         public override void SetPixel(int x, int y, byte r, byte g, byte b)
         {
             var offset = (y * Stride) + (x * BytesPerPixel);
@@ -37,6 +47,7 @@ namespace Iot.Device.Ws28xx.Esp32
             Array.Clear(Data, 0, Data.Length);
         }
 
+        /// <inheritdoc />
         public override void Clear(int x, int y)
         {
             var offset = (y * Stride) + (x * BytesPerPixel);

--- a/devices/Ws28xx.Esp32/BitmapImageWs2808GRB.cs
+++ b/devices/Ws28xx.Esp32/BitmapImageWs2808GRB.cs
@@ -7,7 +7,7 @@ using System.Drawing;
 namespace Iot.Device.Ws28xx.Esp32
 {
     /// <summary>
-    /// BitmapImage Ws2808 GRB
+    /// BitmapImage Ws2808 GRB.
     /// </summary>
     public class BitmapImageWs2808Grb : BitmapImage
     {

--- a/devices/Ws28xx.Esp32/BitmapImageWs2808GRB.cs
+++ b/devices/Ws28xx.Esp32/BitmapImageWs2808GRB.cs
@@ -6,7 +6,7 @@ using System.Drawing;
 
 namespace Iot.Device.Ws28xx.Esp32
 {
-    internal class BitmapImageWs2808Grb : BitmapImage
+    public class BitmapImageWs2808Grb : BitmapImage
     {
         private const int BytesPerPixel = 3;
 

--- a/devices/Ws28xx.Esp32/Ws28xx.cs
+++ b/devices/Ws28xx.Esp32/Ws28xx.cs
@@ -19,22 +19,22 @@ namespace Iot.Device.Ws28xx.Esp32
         /// <summary>
         /// Gets or sets the One pulse command.
         /// </summary>
-        internal RmtCommand OnePulse { get; set; }
+        public RmtCommand OnePulse { get; set; }
 
         /// <summary>
         /// Gets or sets the zero pulse command.
         /// </summary>
-        internal RmtCommand ZeroPulse { get; set; }
+        public RmtCommand ZeroPulse { get; set; }
 
         /// <summary>
         /// Gets or sets the reset command.
         /// </summary>
-        internal RmtCommand ResetCommand { get; set; }
+        public RmtCommand ResetCommand { get; set; }
 
         /// <summary>
         /// Gets or sets the clock divider.
         /// </summary>
-        internal byte ClockDivider { get; set; } = 2;
+        public byte ClockDivider { get; set; } = 2;
 
         /// <summary>
         /// Gets backing image to be updated on the driver.


### PR DESCRIPTION
<!--- In the TITLE (↑↑↑↑ above ↑↑↑↑ **NOT HERE**) provide a general, short summary of your changes -->
<!--- Please DO NOT use references to other PR's or issues -->

## Description
<!--- Describe your changes in detail -->
<!--- Bulleted list. Full sentences. Ending with a dot. -->

- Made the class base `BitmapImage` class public
- Made the `ClockDivider`, `OnePulse`, `ZeroPulse`, and `ResetCommand` parameters in `ws28xx` public.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If this **fixes** OR **closes** OR  **resolves** an open issue, please link to the issue there using the template bellow (mind the pattern to link there as all issues are tracked in the Home repository) -->
<!--- **JUST** replace NNNNN with the issue number -->

I encountered difficulties when using the Iot.Device.Ws28xx.Esp32 library due to my WS2812B device possibly being non-standard, with the model number XL-0807RGBC-WS2812B. When attempting to control it, I found that the Ws2815b in Iot.Device.Ws28xx.Esp32 could not drive it, while Ws2815c could, but the colors were reversed.

The README suggests inheriting from the Ws28xx class and making necessary modifications. However, the BitmapImageWs2808Grb and BitmapImageWs2808 classes, which could otherwise be used directly, are internal and thus cannot be inherited. Even though the source code could be inherited directly from BitmapImage, the parameters within Ws28xx, namely ClockDivider, OnePulse, ZeroPulse, and ResetCommand, are also internal and cannot be inherited. This means that I would need to rewrite all these parameters myself, which greatly reduces the usefulness of the library.

My motivation for this change is to make these classes and parameters public, allowing users to inherit them and modify as needed, enhancing the library's flexibility and usability.

- Resolves nanoframework/Home#1433

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
