### PR TITLE
[RgbDiode] Fixes transition

### DIFF
--- a/devices/RgbDiode/RgbDiode.nfproj
+++ b/devices/RgbDiode/RgbDiode.nfproj
@@ -36,13 +36,15 @@
   <ItemGroup>
     <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="nanoFramework.Graphics.Core, Version=1.2.4.0, Culture=neutral, PublicKeyToken=c07d481e9758c731, processorArchitecture=MSIL">
       <HintPath>packages\nanoFramework.Graphics.Core.1.2.4\lib\nanoFramework.Graphics.Core.dll</HintPath>
     </Reference>
     <Reference Include="System.Device.Pwm">
       <HintPath>packages\nanoFramework.System.Device.Pwm.1.1.10\lib\System.Device.Pwm.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Math">
+      <HintPath>packages\nanoFramework.System.Math.1.5.43\lib\System.Math.dll</HintPath>
     </Reference>
     <Reference Include="System.Threading, Version=1.1.32.63105, Culture=neutral, PublicKeyToken=c07d481e9758c731, processorArchitecture=MSIL">
       <HintPath>packages\nanoFramework.System.Threading.1.1.32\lib\System.Threading.dll</HintPath>

--- a/devices/RgbDiode/RgbDiode.nuspec
+++ b/devices/RgbDiode/RgbDiode.nuspec
@@ -22,6 +22,7 @@
       <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
       <dependency id="nanoFramework.System.Device.Pwm" version="1.1.10" />
       <dependency id="nanoFramework.Graphics.Core" version="1.2.4" />
+      <dependency id="nanoFramework.System.Math" version="1.5.43" />
       <dependency id="nanoFramework.System.Threading" version="1.1.32" />
     </dependencies>
   </metadata>

--- a/devices/RgbDiode/packages.config
+++ b/devices/RgbDiode/packages.config
@@ -3,7 +3,8 @@
   <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnano1.0" />
   <package id="nanoFramework.Graphics.Core" version="1.2.4" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Device.Pwm" version="1.1.10" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Math" version="1.5.43" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Threading" version="1.1.32" targetFramework="netnano1.0" />
   <package id="Nerdbank.GitVersioning" version="3.6.133" targetFramework="netnano1.0" developmentDependency="true" />
   <package id="StyleCop.MSBuild" version="6.2.0" targetFramework="netnano1.0" developmentDependency="true" />
-  <package id="nanoFramework.System.Threading" version="1.1.32" targetFramework="netnano1.0" />
 </packages>

--- a/devices/RgbDiode/packages.lock.json
+++ b/devices/RgbDiode/packages.lock.json
@@ -20,6 +20,12 @@
         "resolved": "1.1.10",
         "contentHash": "vk/Dr8No2ec+eBwwufxDK0Rm6BRnOoevjaqEXbvpFz2BK3UPiC4OhUWH3Rwel34rywg1mXozAAY9ZwvN2gnxlA=="
       },
+      "nanoFramework.System.Math": {
+        "type": "Direct",
+        "requested": "[1.5.43, 1.5.43]",
+        "resolved": "1.5.43",
+        "contentHash": "JEOEGHoIpknJFwPjjz77sT5mej2PiT7JTv59jabzFf+d8XYy8Z4SH+NdX00Xc/yDS8LIPuWb7+C245XGUUx99A=="
+      },
       "nanoFramework.System.Threading": {
         "type": "Direct",
         "requested": "[1.1.32, 1.1.32]",

--- a/devices/RgbDiode/samples/Program.cs
+++ b/devices/RgbDiode/samples/Program.cs
@@ -14,13 +14,19 @@ const byte blueGpioPin = 26;
 // nanoFramework.Hardware.Esp32.Configuration.SetPinFunction(blueGpioPin, nanoFramework.Hardware.Esp32.DeviceFunction.PWM3);
 
 var pwm = new RgbDiode(redGpioPin, greenGpioPin, blueGpioPin);
-pwm.SetColor(255, 0, 0); // Should display red
-pwm.SetColor(0, 255, 0); // Should display green
-pwm.SetColor(0, 0, 255); // Should display blue
+
+// Should display red
+pwm.SetColor(255, 0, 0);
+// Should display green
+pwm.SetColor(0, 255, 0);
+// Should display blue
+pwm.SetColor(0, 0, 255);
 
 pwm.SetColor(Color.LawnGreen);
 pwm.SetColor(Color.OrangeRed);
 pwm.SetColor(Color.Teal);
 
-pwm.Transition(Color.FromArgb(0, 255, 0)); // Will fade blue to green
-pwm.Transition(Color.FromArgb(255, 0, 0)); // Will fade green to red
+// Will fade blue to green
+pwm.Transition(Color.FromArgb(0, 255, 0));
+// Will fade green to red
+pwm.Transition(Color.FromArgb(255, 0, 0));

--- a/devices/RgbDiode/samples/RgbDiode.samples.nfproj
+++ b/devices/RgbDiode/samples/RgbDiode.samples.nfproj
@@ -20,7 +20,6 @@
   <ItemGroup>
     <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="nanoFramework.Graphics.Core, Version=1.2.4.0, Culture=neutral, PublicKeyToken=c07d481e9758c731, processorArchitecture=MSIL">
       <HintPath>..\packages\nanoFramework.Graphics.Core.1.2.4\lib\nanoFramework.Graphics.Core.dll</HintPath>

--- a/devices/RgbDiode/samples/packages.lock.json
+++ b/devices/RgbDiode/samples/packages.lock.json
@@ -14,29 +14,11 @@
         "resolved": "1.2.4",
         "contentHash": "rr9GjMQ3Fucn3LQllQOR1D6DAwEF731GRCBxMIqz4YYpPtidy4XsCSyetZeW/ArMoqYRFwyPqaMtKDhrIHwnDg=="
       },
-      "nanoFramework.Hardware.Esp32": {
-        "type": "Direct",
-        "requested": "[1.6.12, 1.6.12]",
-        "resolved": "1.6.12",
-        "contentHash": "jYlXdtzTu46FfOEfrmhZxYqmHHFAORPqBAS0/S+xWNnnVRhwO/HAGWWheCcu4PN2uPEOgV2X6YOCs1xYRcpopw=="
-      },
-      "nanoFramework.Runtime.Events": {
-        "type": "Direct",
-        "requested": "[1.11.15, 1.11.15]",
-        "resolved": "1.11.15",
-        "contentHash": "3uDNSTfiaewDAyi6fOMWYru0JCn/gr8DEv+Ro/V12SzojU9Dyxl5nSVOBtBXts7vErfIthB6SPiK180AMnrI8A=="
-      },
       "nanoFramework.System.Device.Pwm": {
         "type": "Direct",
         "requested": "[1.1.10, 1.1.10]",
         "resolved": "1.1.10",
         "contentHash": "vk/Dr8No2ec+eBwwufxDK0Rm6BRnOoevjaqEXbvpFz2BK3UPiC4OhUWH3Rwel34rywg1mXozAAY9ZwvN2gnxlA=="
-      },
-      "nanoFramework.System.Threading": {
-        "type": "Direct",
-        "requested": "[1.1.32, 1.1.32]",
-        "resolved": "1.1.32",
-        "contentHash": "6o7Y4gH15FLuo2FWGLecABiCD57V5QMf5g/hEneV64VmhoXI8Bk7r6BDBPTfAePs738xbc1ECpA5dJmbSmtilg=="
       }
     }
   }


### PR DESCRIPTION
## Description
- Improve computation of transition steps so it ends in the expected value.
- Change parameter type on some methods.
- Add ref to Math library in order to round and clamp RGB values.
- Update nuspec accordingly.
- Minor code style updates as the code was being changes.

## Motivation and Context
- The transition was leaving "behind" the previous color component in case the steps were negative or didn't reach the final value.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
