### PR TITLE
Add RS232 support for Modbus library

### DIFF
--- a/devices/Modbus/Client/ModbusClient.cs
+++ b/devices/Modbus/Client/ModbusClient.cs
@@ -22,13 +22,15 @@ namespace Iot.Device.Modbus.Client
         /// <param name="parity">The parity. Default is None.</param>
         /// <param name="dataBits">The number of data bits. Default is 8.</param>
         /// <param name="stopBits">The number of stop bits. Default is One.</param>
+        /// <param name="mode">The mode of serial port, default is RS485.</param>
         public ModbusClient(
             string portName,
             int baudRate = 9600,
             Parity parity = Parity.None,
             int dataBits = 8,
-            StopBits stopBits = StopBits.One)
-            : base(portName, baudRate, parity, dataBits, stopBits)
+            StopBits stopBits = StopBits.One,
+            SerialMode mode = SerialMode.RS485)
+            : base(portName, baudRate, parity, dataBits, stopBits, mode: mode)
         {
         }
 
@@ -36,7 +38,8 @@ namespace Iot.Device.Modbus.Client
         /// Initializes a new instance of the <see cref="ModbusClient"/> class with the specified serial port.
         /// </summary>
         /// <param name="port">The serial port.</param>
-        public ModbusClient(SerialPort port) : base(port)
+        /// <param name="mode">The mode of serial port, default is RS485.</param>
+        public ModbusClient(SerialPort port, SerialMode mode = SerialMode.RS485) : base(port, mode: mode)
         {
         }
 

--- a/devices/Modbus/Port.cs
+++ b/devices/Modbus/Port.cs
@@ -47,16 +47,18 @@ namespace Iot.Device.Modbus
         /// <param name="dataBits">The number of data bits.</param>
         /// <param name="stopBits">The number of stop bits.</param>
         /// <param name="receivedBytesThreshold">The number of bytes required before the DataReceived event is fired. Default is 1.</param>
+        /// <param name="mode">The mode of serial port, default is RS485.</param>
         public Port(
             string portName,
             int baudRate,
             Parity parity,
             int dataBits,
             StopBits stopBits,
-            int receivedBytesThreshold = 1)
+            int receivedBytesThreshold = 1,
+            SerialMode mode = SerialMode.RS485)
         {
             _serialPort = new SerialPort(portName, baudRate, parity, dataBits, stopBits);
-            _serialPort.Mode = SerialMode.RS485;
+            _serialPort.Mode = mode;
             _serialPort.Handshake = Handshake.RequestToSend;
             _serialPort.ReceivedBytesThreshold = receivedBytesThreshold;
         }
@@ -66,10 +68,11 @@ namespace Iot.Device.Modbus
         /// </summary>
         /// <param name="port">The serial port.</param>
         /// <param name="receivedBytesThreshold">The number of bytes required before the DataReceived event is fired. Default is 1.</param>
-        public Port(SerialPort port, int receivedBytesThreshold = 1)
+        /// <param name="mode">The mode of serial port, default is RS485.</param>
+        public Port(SerialPort port, int receivedBytesThreshold = 1, SerialMode mode = SerialMode.RS485)
         {
             _serialPort = port;
-            _serialPort.Mode = SerialMode.RS485;
+            _serialPort.Mode = mode;
 
             if (receivedBytesThreshold != 1)
             {
@@ -178,7 +181,7 @@ namespace Iot.Device.Modbus
         /// </summary>
         /// <param name="bytesToRead">The number of bytes available to read.</param>
         protected virtual void DataReceived(int bytesToRead)
-        { 
+        {
         }
 
         /// <summary>

--- a/devices/Modbus/README.md
+++ b/devices/Modbus/README.md
@@ -61,7 +61,7 @@ When using Modbus with an RS485, you can for example use a MAX485 to make the in
 You can change the ```mode``` parameter in constructor to 0 (SerialMode.Normal) if you're using Modbus over RS232
 ```csharp
 // Modbus Client
-var client = new ModbusClient("COM3",0); //SerialMode.Normal=0 SerialMode.RS485=1
+var client = new ModbusClient("COM3",0); //SerialMode.Normal = 0, SerialMode.RS485 = 1
 // Modbus Server
 var server = new ModbusServer(new Device(1), "COM2",mode:0);
 ```

--- a/devices/Modbus/README.md
+++ b/devices/Modbus/README.md
@@ -61,9 +61,9 @@ When using Modbus with an RS485, you can for example use a MAX485 to make the in
 You can change the ```mode``` parameter in constructor to 0 (SerialMode.Normal) if you're using Modbus over RS232
 ```csharp
 // Modbus Client
-var client = new ModbusClient("COM3",0); //SerialMode.Normal = 0, SerialMode.RS485 = 1
+var client = new ModbusClient("COM3",SerialMode.Normal); 
 // Modbus Server
-var server = new ModbusServer(new Device(1), "COM2",mode:0);
+var server = new ModbusServer(new Device(1), "COM2",mode:SerialMode.Normal);
 ```
 
 ## Limitations

--- a/devices/Modbus/README.md
+++ b/devices/Modbus/README.md
@@ -56,6 +56,16 @@ When using Modbus with an RS485, you can for example use a MAX485 to make the in
 
 ![MAX485](MAX485.png)
 
+## RS232 support
+
+You can change the ```mode``` parameter in constructor to 0 (SerialMode.Normal) if you're using Modbus over RS232
+```csharp
+// Modbus Client
+var client = new ModbusClient("COM3",0); //SerialMode.Normal=0 SerialMode.RS485=1
+// Modbus Server
+var server = new ModbusServer(new Device(1), "COM2",mode:0);
+```
+
 ## Limitations
 
 **NOTE:** nanoFramework only (currently) supports the "Modbus-RTU" protocol.

--- a/devices/Modbus/Server/ModbusServer.cs
+++ b/devices/Modbus/Server/ModbusServer.cs
@@ -25,14 +25,16 @@ namespace Iot.Device.Modbus.Server
         /// <param name="parity">The parity.</param>
         /// <param name="dataBits">The number of data bits.</param>
         /// <param name="stopBits">The stop bits.</param>
+        /// <param name="mode">The mode of serial port, default is RS485.</param>
         public ModbusServer(
             ModbusDevice device,
             string portName,
             int baudRate = 9600,
             Parity parity = Parity.None,
             int dataBits = 8,
-            StopBits stopBits = StopBits.One)
-            : base(portName, baudRate, parity, dataBits, stopBits, 6)
+            StopBits stopBits = StopBits.One,
+            SerialMode mode = SerialMode.RS485)
+            : base(portName, baudRate, parity, dataBits, stopBits, 6, mode: mode)
         {
             _device = device;
         }
@@ -42,7 +44,8 @@ namespace Iot.Device.Modbus.Server
         /// </summary>
         /// <param name="device">The Modbus device.</param>
         /// <param name="port">The serial port.</param>
-        public ModbusServer(ModbusDevice device, SerialPort port) : base(port, 6)
+        /// <param name="mode">The mode of serial port, default is RS485.</param>
+        public ModbusServer(ModbusDevice device, SerialPort port, SerialMode mode = SerialMode.RS485) : base(port, 6, mode)
         {
             _device = device;
         }

--- a/devices/Modbus/samples/Program.cs
+++ b/devices/Modbus/samples/Program.cs
@@ -38,7 +38,7 @@ namespace Iot.Device.Modbus.Samples
             var client = new ModbusClient("COM3");
 
             // Modbus Client (RS232 mode)
-            // var client = new ModbusClient("COM3");
+            // var client = new ModbusClient("COM3",mode:SerialMode.Normal);
 
             client.ReadTimeout = client.WriteTimeout = 2000;
 

--- a/devices/Modbus/samples/Program.cs
+++ b/devices/Modbus/samples/Program.cs
@@ -5,6 +5,7 @@ using nanoFramework.Hardware.Esp32;
 
 using Iot.Device.Modbus.Client;
 using Iot.Device.Modbus.Server;
+using System.IO.Ports;
 
 namespace Iot.Device.Modbus.Samples
 {
@@ -24,13 +25,21 @@ namespace Iot.Device.Modbus.Samples
             Configuration.SetPinFunction(26, DeviceFunction.COM3_TX);
             Configuration.SetPinFunction(27, DeviceFunction.COM3_RTS);
 
-            // Modbus Server
+            // Modbus Server (RS485 mode)
             var server = new ModbusServer(new Device(1), "COM2");
+
+            // Modbus Server (RS232 mode)
+            // var server= new ModbusServer(new Device(1),"COM2",mode:SerialMode.Normal);
+
             server.ReadTimeout = server.WriteTimeout = 2000;
             server.StartListening();
 
-            // Modbus Client
+            // Modbus Client (RS485 mode)
             var client = new ModbusClient("COM3");
+
+            // Modbus Client (RS232 mode)
+            // var client = new ModbusClient("COM3");
+
             client.ReadTimeout = client.WriteTimeout = 2000;
 
             client.WriteMultipleRegisters(2, 0x5, new ushort[] { 3, 5, 2, 3 });


### PR DESCRIPTION
## Description
Add an optional parameter ```(SeiralMode mode = SerialMode.RS485)``` in ModbusClient and ModbusServer constructor.


## Motivation and Context
This change is to support ModBus over RS232. Current library will force set SeiralMode to RS485 which makes it does not work on Modbus over RS232 devices.
<!--- Why is this change required? What problem does it solve? -->
<!--- If this **fixes** OR **closes** OR  **resolves** an open issue, please link to the issue there using the template bellow (mind the pattern to link there as all issues are tracked in the Home repository) -->
<!--- **JUST** replace NNNNN with the issue number -->
- Fixes nanoFramework/Home#1473

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
This modified version is tested with my [MPPTSunDevice](https://github.com/JohnMasen/MPPTSunDevice) project, which controls solar power system via Modbus over RS232.

## Screenshots<!-- (IF APPROPRIATE): -->
N/A
## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [X] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [X] My code follows the code style of this project (only if there are changes in source code).
- [X] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [X] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [X] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [X] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [X] I have added new tests to cover my changes.
