### PR TITLE
[Dhtxx.Esp32] Improvements when processing bad/invalid readings

### DIFF
--- a/devices/Dhtxx.Esp32/DhtBase.cs
+++ b/devices/Dhtxx.Esp32/DhtBase.cs
@@ -227,6 +227,11 @@ namespace Iot.Device.DHTxx.Esp32
                     IsLastReadSuccessful = false;
                 }
             }
+            else
+            {
+                IsLastReadSuccessful = false;
+                _readBuff = new byte[5];
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
## Description
- Reset _readBuff and isLastReadSuccessful if we dont recive valid data.
- if no valid data receive from sensor, then reset _readBuff  and isLastReadSuccessful.

## Motivation and Context
Scenario: Connect the sensor (DHT) to the ESP32 and read data from it. Then, unplug the sensor (DHT) from the ESP32.What Happen Now??! the ReadThroughOneWire method returns the last data, and IsLastReadSuccessful is true ! (this is not correct , when the sensor is unplugged, we expect no data be send as output), In this change, _readBuff will be clear, and IsLastReadSuccessful will be false if we don’t receive valid data form sensor.

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [ ] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [ ] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
