### PR TITLE
[GnssDevice] Adjusting for full .NET code compatibility

### DIFF
--- a/devices/GnssDevice/GenericSerialGnssDevice.cs
+++ b/devices/GnssDevice/GenericSerialGnssDevice.cs
@@ -41,7 +41,9 @@ namespace Iot.Device.Common.GnssDevice
             _serialPort = new SerialPort(portName, baudRate, parity, dataBits, stopBits);
             _serialPort.ReadBufferSize = 2048;
             _serialPort.ReadTimeout = 2000;
+#if NANOFRAMEWORK_1_0
             _serialPort.WatchChar = '\n';
+#endif
             _shouldDispose = true;
         }
 
@@ -125,7 +127,11 @@ namespace Iot.Device.Common.GnssDevice
                 var buffer = new byte[serialDevice.BytesToRead];
                 var bytesRead = serialDevice.Read(buffer, 0, buffer.Length);
                 var stringBuffer = Encoding.UTF8.GetString(buffer, 0, bytesRead);
+#if NANOFRAMEWORK_1_0
                 var commands = stringBuffer.Split(serialDevice.WatchChar);
+#else
+                var commands = stringBuffer.Split('\n');
+#endif
                 foreach (var command in commands)
                 {
                     if (command.Length > 4)


### PR DESCRIPTION
<!--- In the TITLE (↑↑↑↑ above ↑↑↑↑ **NOT HERE**) provide a general, short summary of your changes -->
<!--- Please DO NOT use references to other PR's or issues -->

## Description
<!--- Describe your changes in detail -->
<!--- Bulleted list. Full sentences. Ending with a dot. -->
[GnssDevice] Adjusting for full .NET code compatibility

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If this **fixes** OR **closes** OR  **resolves** an open issue, please link to the issue there using the template bellow (mind the pattern to link there as all issues are tracked in the Home repository) -->
<!--- **JUST** replace NNNNN with the issue number -->
- Watchchar is not supported in SerialPort in the full .NET. To easy the compatibility with full .NET (used in the AtModem code for debug), adding specific code to handle the difference.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
With the AtModem code

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
