### PR TITLE
[AtModem] Fix NullReferenceException in AtChannel.ReaderLoopAsync

### DIFF
--- a/devices/AtModem/AtParser/AtChannel.cs
+++ b/devices/AtModem/AtParser/AtChannel.cs
@@ -335,8 +335,11 @@ namespace Iot.Device.AtModem
             }
             finally
             {
-                _currentCommand = default;
-                _currentResponse = default;
+                lock (_lock)
+                {
+                    _currentCommand = default;
+                    _currentResponse = default;
+                }
             }
         }
 

--- a/devices/AtModem/Modem/ModemBase.cs
+++ b/devices/AtModem/Modem/ModemBase.cs
@@ -722,7 +722,7 @@ namespace Iot.Device.AtModem.Modem
 
                     // The first one is the notification level with proactive +CREG
                     ////int n = int.Parse(parts[0]);
-                    int stat = parts.Length >= 2 ? int.Parse(parts[1]) : 0;
+                    int stat = int.Parse(parts[1]);
                     return ModemResponse.ResultSuccess((NetworkRegistration)stat);
                 }
             }

--- a/devices/AtModem/Modem/ModemBase.cs
+++ b/devices/AtModem/Modem/ModemBase.cs
@@ -722,7 +722,7 @@ namespace Iot.Device.AtModem.Modem
 
                     // The first one is the notification level with proactive +CREG
                     ////int n = int.Parse(parts[0]);
-                    int stat = int.Parse(parts[1]);
+                    int stat = parts.Length >= 2 ? int.Parse(parts[1]) : 0;
                     return ModemResponse.ResultSuccess((NetworkRegistration)stat);
                 }
             }


### PR DESCRIPTION
## Description
- Right after the lock in AtChannel.ReaderLoopAsync it is checked if _currentCommand != null. After that _currentCommand is used to do other checks.
- Sometimes these last checks give a NullReferenceException because another thread sets _currentCommand to null in the 'finally' of AtChannel.SendFullCommand. This sometimes happens after an hour or so..

- To fix this we can put a lock around the code in the 'finally' of AtChannel.SendFullCommand so the checking and using and the setting to null are mutually exclusive and the NullReferenceException doesn't happen.

## Motivation and Context
- This bug is caused by multithreading in the AtChannel class. It happens in a specific situation and most of the times only after hours of http POST-ing messages.
- When this is fixed it will not cause NullReferenceExceptions
- Fixes nanoFramework/Home#1579

## How Has This Been Tested?
This has been tested by POST-ing messages for many hours and days and logging the output to the Putty COM watcher.

## Screenshots
Not Appropriate

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
