### PR TITLE
[AtModem] Fix Uncaught exception in ModemBase.GetNetworkRegistration()

### DIFF
--- a/devices/AtModem/Modem/ModemBase.cs
+++ b/devices/AtModem/Modem/ModemBase.cs
@@ -722,7 +722,7 @@ namespace Iot.Device.AtModem.Modem
 
                     // The first one is the notification level with proactive +CREG
                     ////int n = int.Parse(parts[0]);
-                    int stat = int.Parse(parts[1]);
+                    int stat = parts.Length >= 2 ? int.Parse(parts[1]) : 0;
                     return ModemResponse.ResultSuccess((NetworkRegistration)stat);
                 }
             }


### PR DESCRIPTION
## Description
After sending "AT+CREG?" the answer sometimes doesn't contain a ','.

Like in:
 • +CREG: 1,0
 • +CREG: 1,0
 • +CREG: 1
 • +CREG: 1,1

Then an uncaught exception is thrown because of the line:

                    int stat = int.Parse(parts[x]);

But this doesn't happen very often. Only once every 10 networkregistrations  or so…

The fix is to check the lenght before asuming there are at least 2 parts.

## Motivation and Context
- This bug sometimes causes Uncaught Exceptions. It happens only every 10 NetworkRegistrations or so.
- When the system reboots (after an Error or a watchdog trigger) the NetworkRegistration is performed again.
- When this gives an Uncaught exception the results are possibly a hanging system.
- This fix makes the system more stable.
- Fixes nanoFramework/Home#1579

## How Has This Been Tested?
- It has been tested by running the system for days while it occasionally reboots. Everytime it needs to call GetNetworkRegistration(). The output of the system is monitored by Putty and written to logfiles.
These logfiles don't show this particular Uncaught Exception anymore.

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
