### PR TITLE
[AtModem] Fix HTTP init retry mechanism SIM7672

### DIFF
--- a/devices/AtModem/Http/Sim7672HttpClient.cs
+++ b/devices/AtModem/Http/Sim7672HttpClient.cs
@@ -90,15 +90,23 @@ namespace Iot.Device.AtModem.Http
                 int index;
                 int retries = 5;
 
+            Retry:
                 // We init, if already init, try to deiniti and reinit
                 response = Modem.Channel.SendCommand($"AT+HTTPINIT");
                 if (!response.Success)
                 {
-                    Modem.Channel.SendCommand($"AT+HTTPTERM");
-                    Modem.Channel.SendCommand($"AT+HTTPINIT");
+                    // Give it another try
+                    if (retries-- > 0)
+                    {
+                        // Experience shows that 1 second is ok in most of the times
+                        Thread.Sleep(1000);
+                        Modem.Channel.SendCommand($"AT+HTTPTERM");
+                        goto Retry;
+                    }
+
+                    return result;
                 }
 
-            Retry:
                 if (request.RequestUri.Scheme == "https")
                 {
                     // This is to read the current configuration, we don't need it now.

--- a/devices/AtModem/Http/Sim7672HttpClient.cs
+++ b/devices/AtModem/Http/Sim7672HttpClient.cs
@@ -98,7 +98,6 @@ namespace Iot.Device.AtModem.Http
                     // Give it another try
                     if (retries-- > 0)
                     {
-                        // Experience shows that 1 second is ok in most of the times
                         Thread.Sleep(250);
                         Modem.Channel.SendCommand($"AT+HTTPTERM");
                         goto Retry;

--- a/devices/AtModem/Http/Sim7672HttpClient.cs
+++ b/devices/AtModem/Http/Sim7672HttpClient.cs
@@ -99,7 +99,7 @@ namespace Iot.Device.AtModem.Http
                     if (retries-- > 0)
                     {
                         // Experience shows that 1 second is ok in most of the times
-                        Thread.Sleep(1000);
+                        Thread.Sleep(250);
                         Modem.Channel.SendCommand($"AT+HTTPTERM");
                         goto Retry;
                     }


### PR DESCRIPTION
<!--- In the TITLE (↑↑↑↑ above ↑↑↑↑ **NOT HERE**) provide a general, short summary of your changes -->
<!--- Please DO NOT use references to other PR's or issues -->

## Description
<!--- Describe your changes in detail -->
<!--- Bulleted list. Full sentences. Ending with a dot. -->
The first thing that is necessary to send a HTTP message is to send the "AT+HTTPINIT" command. In the current situation when this fails, it will try it one more time and when that fails it just continues as if nothing is wrong..

The unused "Retry:" and the "int retries = 5" variable suggest that there once was a retry mechanism and in the Sim800HttpClient there is.

So I copied this retry mechanism to the Sim7672HttpClient.SendInternal, including the return of "ServiceUnavailable" when it fails after 5 retries.

I haven't noticed this gone wrong but the original implementation suggests it might. And after this fix it is handled correctly.
So it improves the stabillity of the system. And the consistence.

Signed-off-by: Rik Kreeftenberg <rik.kreeftenberg@spinsoft.nl>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If this **fixes** OR **closes** OR  **resolves** an open issue, please link to the issue there using the template below -->
This fix is required to handle possible fails to HTTPINIT the modem correctly and in line with the SIM800 modem.
Is it an improvement or a fix? I say it's a bug because only part of the retry mechanism is implemented and when the original retry fails, the system just continues and won't work correctly.

(mind the pattern to link there as all issues are tracked in the Home repository) -->
<!--- **JUST** replace NNNNN with the issue number -->
- Fixes nanoFramework/Home#1579

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This has been tested by sending thousends of http messages to an Azure Function app for days on end and monitoring the output with Putty and logfiles. 
To be honest I haven't seen the Retry system kick in and saving the day, but that may happen some times. 

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
