### PR TITLE
[AtModem] Fix NullReferenceException in AtChannel.ProcessMessage

### DIFF
--- a/devices/AtModem/AtParser/AtChannel.cs
+++ b/devices/AtModem/AtParser/AtChannel.cs
@@ -409,7 +409,11 @@ namespace Iot.Device.AtModem
                 }
                 else
                 {
-                    ProcessMessage(line1);
+                    // lock access to _currentCommand & _currentResponse
+                    lock (_lock)
+                    {
+                        ProcessMessage(line1);
+                    }
                 }
             }
         }


### PR DESCRIPTION
<!--- In the TITLE (↑↑↑↑ above ↑↑↑↑ **NOT HERE**) provide a general, short summary of your changes -->
<!--- Please DO NOT use references to other PR's or issues -->

## Description
<!--- Describe your changes in detail -->
<!--- Bulleted list. Full sentences. Ending with a dot. -->
The _currentCommand and the _currentResponse are used troughout the AtChannel class. They are set to null in the 'finally' of the AtChannel.SendFullCommand. But in very few occasions (once every hour or so) the _currentCommand is used by another thread after it has been set to null, resulting in a NullReferenceException. For example in HandleFinalResponse. This is the same multi-threading problem like the one fixed in PR #1216.

We can fix this by placing a lock around the call to AtChannel.ProcessMessage so access to _currentCommand and _currentresponse is mutually exclusive to setting them to null. So NullReference cannot occur.

This also discussed with @Ellerbach  in https://discord.com/channels/478725473862549535/1320052446227071116/1323303047895449642

Signed-off-by: Rik Kreeftenberg <rik.kreeftenberg@spinsoft.nl>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If this **fixes** OR **closes** OR  **resolves** an open issue, please link to the issue there using the template bellow (mind the pattern to link there as all issues are tracked in the Home repository) -->
This fixes the last NullreferenceException that I came accross during my testing of the AtModem library.
<!--- **JUST** replace NNNNN with the issue number -->
- Addresses nanoFramework/Home#1579

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I have tested this by POST'ing thousands of messages to an Azure Function app for a day and checking if there are any uncaught exceptions written to a logfile created by connecting Putty to the debug port. There weren't.. ;-)
## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [] New feature (non-breaking change which adds functionality to code)
- [] Breaking change (fix or feature that would cause existing functionality to change)
- [] Config and build (change in the configuration and build system, has no impact on code or features)
- [] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [] I have added new tests to cover my changes.
