### PR TITLE
Device list CLI now uses nuspec to list NuGet package

### DIFF
--- a/src/device-listing/Program.cs
+++ b/src/device-listing/Program.cs
@@ -111,25 +111,7 @@ string GetDeviceListing(string devicesPath, IEnumerable<DeviceInfo> devices)
     var deviceListing = new StringBuilder();
     foreach (DeviceInfo device in devices)
     {
-        if (device.Name.StartsWith("System"))
-        {
-            deviceListing.AppendLine($"* [![NuGet](https://img.shields.io/nuget/v/nanoFramework.{device.Name}.svg?label=NuGet&style=flat&logo=nuget)](https://www.nuget.org/packages/nanoFramework.{device.Name}/) [{device.Title}]({CreateMarkdownLinkFromPath(device.ReadmePath, devicesPath)})");
-        }
-        else
-        {
-            if ((device.Name == "NumberHelper") || (device.Name == "WeatherHelper"))
-            {
-                deviceListing.AppendLine($"* [![NuGet](https://img.shields.io/nuget/v/nanoFramework.IoT.Device.Common.{device.Name}.svg?label=NuGet&style=flat&logo=nuget)](https://www.nuget.org/packages/nanoFramework.IoT.Device.Common.{device.Name}/) [{device.Title}]({CreateMarkdownLinkFromPath(device.ReadmePath, devicesPath)})");
-            }
-            else if (device.Name == "Card")
-            {
-                deviceListing.AppendLine($"* [![NuGet](https://img.shields.io/nuget/v/nanoFramework.IoT.Device.Card.svg?label=NuGet&style=flat&logo=nuget)](https://www.nuget.org/packages/nanoFramework.IoT.Device.Card/) [{device.Title}]({CreateMarkdownLinkFromPath(device.ReadmePath, devicesPath)})");
-            }
-            else
-            {
-                deviceListing.AppendLine($"* [![NuGet](https://img.shields.io/nuget/v/nanoFramework.IoT.Device.{device.Name}.svg?label=NuGet&style=flat&logo=nuget)](https://www.nuget.org/packages/nanoFramework.IoT.Device.{device.Name}/) [{device.Title}]({CreateMarkdownLinkFromPath(device.ReadmePath, devicesPath)})");
-            }
-        }
+        deviceListing.AppendLine($"* [![NuGet](https://img.shields.io/nuget/v/{device.NuGetPackageId}.svg?label=NuGet&style=flat&logo=nuget)](https://www.nuget.org/packages/{device.NuGetPackageId}/) [{device.Title}]({CreateMarkdownLinkFromPath(device.ReadmePath, devicesPath)})");
     }
 
     return deviceListing.ToString();


### PR DESCRIPTION
## Description
- Add new property to hold nuget package ID.
- Add processor to grab package ID from nuspec.
- Now uses new property with package id when composing package label.

## Motivation and Context
- Package ID was using a list of edge cases. 
- GSNN package not being properly labeled triggered me to improve this.
- Using the ID in nuspec makes this more robust and error free.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- Generating new README. Visually confirming that all labels are correctly generated.

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
