### PR TITLE
XPT2046 Driver and Example

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ Most of the bindings have been migrated from [.NET IoT repository](https://githu
 * [![NuGet](https://img.shields.io/nuget/v/nanoFramework.Iot.Device.Vl6180X.svg?label=NuGet&style=flat&logo=nuget)](https://www.nuget.org/packages/nanoFramework.Iot.Device.Vl6180X/) [Vl6180X - distance sensor](devices/Vl6180X)
 * [![NuGet](https://img.shields.io/nuget/v/nanoFramework.Iot.Device.Ws28xx.Esp32.svg?label=NuGet&style=flat&logo=nuget)](https://www.nuget.org/packages/nanoFramework.Iot.Device.Ws28xx.Esp32/) [Ws28xx/WS2812B/WS2815B/WS2808/SK6812/Neo pixel for ESP32 using RMT - LED drivers](devices/Ws28xx.Esp32)
 * [![NuGet](https://img.shields.io/nuget/v/nanoFramework.Iot.Device.Ws28xx.svg?label=NuGet&style=flat&logo=nuget)](https://www.nuget.org/packages/nanoFramework.Iot.Device.Ws28xx/) [Ws28xx/WS2812B/WS2815B/WS2808/SK6812/Neo pixel using SPI - LED drivers](devices/Ws28xx)
+* [![NuGet](https://img.shields.io/nuget/v/nanoFramework.Iot.Device.XPT2046.svg?label=NuGet&style=flat&logo=nuget)](https://www.nuget.org/packages/nanoFramework.Iot.Device.XPT2046/) [XPT2046 - Resistive Touch Screen Controller](devices/XPT2046)
 * [![NuGet](https://img.shields.io/nuget/v/nanoFramework.Iot.Device.Yx5300.svg?label=NuGet&style=flat&logo=nuget)](https://www.nuget.org/packages/nanoFramework.Iot.Device.Yx5300/) [YX5200/YX5300 - MP3 Player](devices/Yx5300)
 </devices>
 

--- a/devices/XPT2046/Point.cs
+++ b/devices/XPT2046/Point.cs
@@ -1,0 +1,29 @@
+//
+// Copyright (c) .NET Foundation and Contributors
+// Portions Copyright (c) Microsoft Corporation.  All rights reserved.
+// See LICENSE file in the project root for full license information.
+//
+
+namespace Iot.Device.XPT2046
+{
+    /// <summary>
+    /// A touch point
+    /// </summary>
+    public struct Point
+    {
+        /// <summary>
+        /// Gets or sets X
+        /// </summary>
+        public int X { get; set; }
+
+        /// <summary>
+        /// Gets or sets Y
+        /// </summary>
+        public int Y { get; set; }
+
+        /// <summary>
+        /// Gets of sets the amount of pressure of the touch.
+        /// </summary>
+        public int Weight { get; set; }
+    }
+}

--- a/devices/XPT2046/Properties/AssemblyInfo.cs
+++ b/devices/XPT2046/Properties/AssemblyInfo.cs
@@ -1,0 +1,39 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Iot.Device.XPT2046")]
+[assembly: AssemblyDescription("XPT2046 Touch Screen Controller driver for .NET nanoFramework")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("nanoFramework Contributors")]
+[assembly: AssemblyProduct("Iot.Device.XPT2046")]
+[assembly: AssemblyCopyright("Copyright © .NET Foundation and Contributors")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("0.0.0.2")]
+[assembly: AssemblyFileVersion("0.0.0.2")]
+
+/////////////////////////////////////////////////////////////////
+// This attribute is mandatory when building Interop libraries //
+// update this whenever the native assembly signature changes  //
+[assembly: AssemblyNativeVersion("0.0.0.2")]
+/////////////////////////////////////////////////////////////////

--- a/devices/XPT2046/README.md
+++ b/devices/XPT2046/README.md
@@ -1,0 +1,101 @@
+# XPT2046 - Touch screen controller
+
+The XPT2046 from XPTEK is a 4-wire resistive touch screen controller that incorporates a 12-bit 125 kHz successive approximation register type A/D converter. The XPT2046 can detect the pressed screen location by performing two A/D conversions. As well as the location, the XPT2046 also measures touch screen pressure. A multiplexer allows it to measure chip temperature and battery voltage.
+
+The XPT2046 is common in a number of touch screen modules from suppliers like WaveShare and an number of ESP32 based display boards.
+
+Communication is via the SPI bus which can communicate at maximum speed of 2Mhz and uses Mode 0 for the clock polarity/phase setting. The host sends an 8 bit command and the chip responds with 16 bits of data althought the first bit and last three bits are not part of the conversion. XPT2046 needs 16 clock cycles to read a value, so this driver sends 8 bits and a padding byte between each command, and the device can be reading one result whilst sending the command for the next measurement. When reading we need to skip the first 8 bits.
+
+An additional interupt pin which is usually in a high state and goes low when a touch is detected. Note that communicating with the chip will interfere with the interupt.
+
+The chip can use an internal voltage reference or be configured to use an external reference if more accuracy is required.
+
+The XPT2046 will enter power down mode and stop communicating when the chip select pin is taken high. This is why TransferFullDuplex is used as the framework does not expose the raw SPI transaction.
+
+The driver does a best of 3 average, thanks Paul Stoffregen for the suggestion via your Arduino library.
+
+## Documentation
+
+Datasheet - https://www.waveshare.com/wiki/File:XPT2046-EN.pdf
+
+## Usage
+
+See TouchDemo for a complete example of usage based on the ESP32 and a cheap yellow display module.
+
+The driver also supports a maximum X and Y value so you can map the output to your screen size.
+
+The driver scales the output based on a maximum X and Y value so you can map it to pixels on your screen.
+
+**Important**: For the ESP32 the default pins can be remapped, do so before creating the `SPIDevice`.
+
+```csharp
+using nanoFramework.Hardware.ESP32;
+    
+    // Pin Definitions for the Cheap Yellow Display
+    const int XPT2046_CS = Gpio.IO33;      // Chip Select
+    const int XPT2046_PenIRQ = Gpio.IO36;  // Touch detected interupt
+    const int XPT2046_COPI = Gpio.IO32;
+    const int XPT2046_CIPO = Gpio.IO39;
+    const int XPT2046_CLK = Gpio.IO25;
+
+    // If you're using an ESP32, use nanoFramework.Hardware.Esp32 to remap the SPI pins
+    Configuration.SetPinFunction(XPT2046_COPI, DeviceFunction.SPI1_MOSI);
+    Configuration.SetPinFunction(XPT2046_CIPO, DeviceFunction.SPI1_CLOCK);
+    Configuration.SetPinFunction(XPT2046_CLK, DeviceFunction.SPI1_MISO);
+```
+
+```csharp
+using System.Device.Spi;
+
+SpiDevice spiDevice;
+SpiConnectionSettings connectionSettings;
+connectionSettings = new SpiConnectionSettings(1, XPT2046_CS);
+connectionSettings.ClockFrequency = 2_000_000;
+connectionSettings.DataBitLength = 8;
+connectionSettings.DataFlow = DataFlow.MsbFirst;
+connectionSettings.Mode = SpiMode.Mode0;
+
+// Then you create your SPI device by passing your settings
+spiDevice = SpiDevice.Create(connectionSettings);
+
+using GpioController gpio = new();
+using Xpt2046 sensor = new(spiDevice);
+var ver = sensor.GetVersion();
+
+Debug.WriteLine($"version: {ver}");
+
+var point = sensor.GetPoint();
+
+Debug.WriteLine($"ID: {point.TouchId}, X: {point.X}, Y: {point.Y}, Weight: {point.Weigth}, Misc: {point.Miscelaneous}");
+
+```
+
+Use with an interupt pin. Note that interupts that happen during conversion are not reliable. Hence setting touchDetected after calling GetPoint();
+
+```csharp
+bool touchDetected = false;
+
+gpio.OpenPin(XPT2046_PenIRQ, PinMode.Input);
+// This will enable an event on GPIO36 on falling edge when the screen if touched
+gpio.RegisterCallbackForPinValueChangedEvent(XPT2046_PenIRQ, PinEventTypes.Falling, TouchInterrupCallback);
+
+while (true)
+{
+    if (touchDetected) {
+        var point = sensor.GetPoint();
+        touchDetected = false;
+        
+        Debug.WriteLine($"ID: {point.TouchId}, X: {point.X}, Y: {point.Y}, Weight: {point.Weigth}, Misc: {point.Miscelaneous}");
+
+        Thread.Sleep(500);
+
+    }
+
+    Thread.Sleep(20);
+}
+
+void TouchInterrupCallback(object sender, PinValueChangedEventArgs pinValueChangedEventArgs)
+{
+    touchDetected = true;
+}
+```

--- a/devices/XPT2046/TouchDemo/Program.cs
+++ b/devices/XPT2046/TouchDemo/Program.cs
@@ -1,0 +1,87 @@
+using Iot.Device.XPT2046;
+using nanoFramework.Hardware.Esp32;
+using System;
+using System.Device.Gpio;
+using System.Device.Spi;
+using System.Diagnostics;
+using System.Threading;
+
+namespace TouchDemo
+{
+
+    
+    public class Program
+    {
+        static bool touchDetected = false;
+
+        public static void Main()
+        {
+            Debug.WriteLine("Hello from nanoFramework!");
+
+            const int XPT2046_CS = Gpio.IO33; // Chip Select
+            const int XPT2046_PenIRQ = Gpio.IO36; // Touch detected interupt
+            const int XPT2046_COPI = Gpio.IO32;
+            const int XPT2046_CIPO = Gpio.IO39;
+            const int XPT2046_CLK = Gpio.IO25;
+
+            try
+            {
+                //Move Display pins to correct SPI bus as the default overlaps with the XPT2046 pins
+                Configuration.SetPinFunction(Gpio.IO13, DeviceFunction.SPI1_MOSI);
+                Configuration.SetPinFunction(Gpio.IO14, DeviceFunction.SPI1_CLOCK);
+                Configuration.SetPinFunction(Gpio.IO12, DeviceFunction.SPI1_MISO);
+
+                // For the XPT2046 Touch controller
+                Configuration.SetPinFunction(XPT2046_COPI, DeviceFunction.SPI2_MOSI);
+                Configuration.SetPinFunction(XPT2046_CIPO, DeviceFunction.SPI2_MISO);
+                Configuration.SetPinFunction(XPT2046_CLK, DeviceFunction.SPI2_CLOCK);
+
+                SpiDevice spiDevice;
+                SpiConnectionSettings connectionSettings;
+
+                connectionSettings = new SpiConnectionSettings(2, XPT2046_CS);
+                connectionSettings.ClockFrequency = 1_000_000;      //Set clock speed to slowest device on bus
+                connectionSettings.DataBitLength = 8;
+                connectionSettings.DataFlow = DataFlow.MsbFirst;
+                connectionSettings.Mode = SpiMode.Mode0;
+
+                spiDevice = SpiDevice.Create(connectionSettings);   // For XPT2046 Touch controller
+
+                using GpioController gpio = new();
+                using Xpt2046 sensor = new(spiDevice);
+                var ver = sensor.GetVersion();
+                Debug.WriteLine($"version: {ver}");
+
+                gpio.OpenPin(XPT2046_PenIRQ, PinMode.InputPullUp);
+                // This will enable an event on GPIO36 on falling edge when the screen if touched
+                gpio.RegisterCallbackForPinValueChangedEvent(XPT2046_PenIRQ, PinEventTypes.Falling, TouchInteruptCallback);
+
+
+                while (true)
+                {
+                    if (touchDetected)
+                    {
+                        var point = sensor.GetPoint();
+                        Debug.WriteLine($"point: {point.X},{point.Y},{point.Weight} ");
+                        Thread.Sleep(30);
+                        touchDetected = false;
+                    }
+
+                    Thread.Sleep(300);
+                }
+
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"Critical Exception, Terminating: {ex.Message}");
+
+                Thread.Sleep(Timeout.Infinite);
+            }
+
+        }
+        static void TouchInteruptCallback(object sender, PinValueChangedEventArgs pinValueChangedEventArgs)
+        {
+            touchDetected = true;
+        }
+    }
+}

--- a/devices/XPT2046/TouchDemo/TouchDemo.nfproj
+++ b/devices/XPT2046/TouchDemo/TouchDemo.nfproj
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="Current" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Label="Globals">
+    <NanoFrameworkProjectSystemPath>$(MSBuildExtensionsPath)\nanoFramework\v1.0\</NanoFrameworkProjectSystemPath>
+  </PropertyGroup>
+  <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.Default.props" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.Default.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectTypeGuids>{11A8DD76-328B-46DF-9F39-F559912D0360};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ProjectGuid>2d7cdabb-6c2c-4957-8a83-9751c75c0435</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <RootNamespace>TouchDemo</RootNamespace>
+    <AssemblyName>TouchDemo</AssemblyName>
+    <TargetFrameworkVersion>v1.0</TargetFrameworkVersion>
+  </PropertyGroup>
+  <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.props" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.props')" />
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\XPT2046.nfproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="mscorlib">
+      <HintPath>packages\nanoFramework.CoreLibrary.1.17.11\lib\mscorlib.dll</HintPath>
+    </Reference>
+    <Reference Include="nanoFramework.Hardware.Esp32">
+      <HintPath>packages\nanoFramework.Hardware.Esp32.1.6.34\lib\nanoFramework.Hardware.Esp32.dll</HintPath>
+    </Reference>
+    <Reference Include="nanoFramework.Runtime.Events">
+      <HintPath>packages\nanoFramework.Runtime.Events.1.11.32\lib\nanoFramework.Runtime.Events.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Device.Gpio">
+      <HintPath>packages\nanoFramework.System.Device.Gpio.1.1.57\lib\System.Device.Gpio.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Device.Spi">
+      <HintPath>packages\nanoFramework.System.Device.Spi.1.3.82\lib\System.Device.Spi.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.CSharp.targets" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.CSharp.targets')" />
+  <ProjectExtensions>
+    <ProjectCapabilities>
+      <ProjectConfigurationsDeclaredAsItems />
+    </ProjectCapabilities>
+  </ProjectExtensions>
+</Project>

--- a/devices/XPT2046/TouchDemo/TouchDemo.sln
+++ b/devices/XPT2046/TouchDemo/TouchDemo.sln
@@ -1,0 +1,35 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.14.36221.1 d17.14
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{11A8DD76-328B-46DF-9F39-F559912D0360}") = "XPT2046", "..\XPT2046.nfproj", "{BC80A2E4-00D8-483D-84B8-3B8F37950DFE}"
+EndProject
+Project("{11A8DD76-328B-46DF-9F39-F559912D0360}") = "TouchDemo", "TouchDemo.nfproj", "{2D7CDABB-6C2C-4957-8A83-9751C75C0435}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{BC80A2E4-00D8-483D-84B8-3B8F37950DFE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BC80A2E4-00D8-483D-84B8-3B8F37950DFE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BC80A2E4-00D8-483D-84B8-3B8F37950DFE}.Debug|Any CPU.Deploy.0 = Debug|Any CPU
+		{BC80A2E4-00D8-483D-84B8-3B8F37950DFE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BC80A2E4-00D8-483D-84B8-3B8F37950DFE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BC80A2E4-00D8-483D-84B8-3B8F37950DFE}.Release|Any CPU.Deploy.0 = Release|Any CPU
+		{2D7CDABB-6C2C-4957-8A83-9751C75C0435}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2D7CDABB-6C2C-4957-8A83-9751C75C0435}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2D7CDABB-6C2C-4957-8A83-9751C75C0435}.Debug|Any CPU.Deploy.0 = Debug|Any CPU
+		{2D7CDABB-6C2C-4957-8A83-9751C75C0435}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2D7CDABB-6C2C-4957-8A83-9751C75C0435}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2D7CDABB-6C2C-4957-8A83-9751C75C0435}.Release|Any CPU.Deploy.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {4A350608-DBCF-4618-9F2B-3AC631E05794}
+	EndGlobalSection
+EndGlobal

--- a/devices/XPT2046/TouchDemo/packages.config
+++ b/devices/XPT2046/TouchDemo/packages.config
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="nanoFramework.CoreLibrary" version="1.17.11" targetFramework="netnano1.0" />
+  <package id="nanoFramework.Hardware.Esp32" version="1.6.34" targetFramework="netnano1.0" />
+  <package id="nanoFramework.Runtime.Events" version="1.11.32" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Device.Gpio" version="1.1.57" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Device.Spi" version="1.3.82" targetFramework="netnano1.0" />
+</packages>

--- a/devices/XPT2046/XPT2046.cs
+++ b/devices/XPT2046/XPT2046.cs
@@ -1,0 +1,194 @@
+﻿//
+// Copyright (c) .NET Foundation and Contributors
+// Portions Copyright (c) Microsoft Corporation.  All rights reserved.
+// See LICENSE file in the project root for full license information.
+//
+
+using System;
+using System.Device.Spi;
+using System.Diagnostics;
+using System.IO;
+
+namespace Iot.Device.XPT2046
+{
+    public class Xpt2046 : IDisposable
+    {
+        private readonly SpiDevice _spiDevice;
+        private readonly int _xMax;
+        private readonly int _yMax;
+        private bool _disposedValue = false;
+
+        private const byte StartBit = 0b10000000;
+        private const int maxConversion = 0b111111111111;
+
+        enum PowerMode
+        {
+            PowerDown = 0,              //Power Down between conversions
+            RefOff_ADCOn_IntOff = 1,    //Reference is off and ADC is on. Interupt off (used for double ended conversion)
+            RefOn_ADCOff_IntOn = 2,     //Reference is on and ADC is off. Interupt on
+            AlwaysOn = 3                //Always on. Interupt is disabled
+        }
+
+        enum MultiplexerChannel : byte
+        {
+            Temperature0 = 0b00000000,
+            Temperature1 = 0b01110000,
+            Battery = 0b00100000,
+            AuxIn = 0b01100000,
+            Z1 = 0b00110000,
+            Z2 = 0b01000000,
+            X = 0b00010000,
+            Y = 0b01010000
+        }
+
+        enum ConversionMode
+        {
+            Bits12 = 0b00000000,
+            Bits8 = 0b00001000
+        }
+
+        enum ReferenceSelectMode
+        {
+            DoubleEnded = 0b00000000,
+            SingleEnded = 0b00000100
+        }
+
+        //See https://docs.nanoframework.net/content/getting-started-guides/spi-explained.html
+
+        /// <summary>
+        /// Creates an instance of an Xpt2046
+        /// </summary>
+        /// <param name="spiBus">The SpiConfiguration connected to the touchscreen controller</param>
+        /// <param name="xMax">The X size of the screen</param>
+        /// <param name="yMax">The Y size of the screen</param>
+        public Xpt2046(SpiDevice spiDevice, int xMax = 320, int yMax = 240)
+        {
+            _spiDevice = spiDevice;
+            _xMax = xMax;
+            _yMax = yMax;
+        }
+
+        /// <summary>
+        /// Returns the version of the Xpt2046 driver.
+        /// </summary>
+        public string GetVersion()
+        {
+            return "0.2";
+        }
+
+        /// <summary>
+        /// Gets the current point from the touchscreen controller.
+        /// </summary>
+        public Point GetPoint()
+        {
+            // Get best of 3 samples
+            Point[] samples = new Point[3];
+            samples[0] = read();
+            samples[1] = read();
+            samples[2] = read();
+
+            // Get the average of the two closest samples
+            return new Point
+            {
+                X = BestTwoOfThreeAverage(samples[0].X, samples[1].X, samples[2].X),
+                Y = BestTwoOfThreeAverage(samples[0].Y, samples[1].Y, samples[2].Y),
+                Weight = BestTwoOfThreeAverage(samples[0].Weight, samples[1].Weight, samples[2].Weight)
+            };
+        }
+
+        private int BestTwoOfThreeAverage(int i1, int i2, int i3)
+        {
+            // If you want to use Math.Abs there's a separate nanoFramework.System.Math package for that.
+            var diff12 = i1 > i2 ? (i1 - i2) : (i2 - i1);
+            var diff13 = i1 > i3 ? (i1 - i3) : (i3 - i1);
+            var diff23 = i2 > i3 ? (i2 - i3) : (i3 - i2);
+
+            if (diff12 <= diff13 && diff12 <= diff23)
+            {
+                return (i1 + i2) / 2;
+            }
+            else if (diff13 <= diff12 && diff13 <= diff23)
+            {
+                return (i1 + i3) / 2;
+            }
+            else
+            {
+                return (i2 + i3) / 2;
+            }
+        }
+
+
+        private Point read()
+        {
+            // Overlapped buffer: control, 0, control, 0, control, 0, control, 0, 0
+            // Total 9 bytes: each control overlaps with previous read except the last
+            SpanByte writeBuffer = new byte[9];
+            SpanByte readBuffer = new byte[9];
+
+            // Prepare all control bytes for overlapped transaction
+            byte z1ControlByte = (byte)StartBit | (byte)MultiplexerChannel.Z1
+                                               | (byte)ConversionMode.Bits12
+                                               | (byte)ReferenceSelectMode.DoubleEnded
+                                               | (byte)PowerMode.RefOff_ADCOn_IntOff;
+
+            byte z2ControlByte = (byte)StartBit | (byte)MultiplexerChannel.Z2
+                                               | (byte)ConversionMode.Bits12
+                                               | (byte)ReferenceSelectMode.DoubleEnded
+                                               | (byte)PowerMode.RefOff_ADCOn_IntOff;
+
+            byte xControlByte = (byte)StartBit | (byte)MultiplexerChannel.X
+                                              | (byte)ConversionMode.Bits12
+                                              | (byte)ReferenceSelectMode.DoubleEnded
+                                              | (byte)PowerMode.RefOff_ADCOn_IntOff;
+
+            // Final Y measurement with PowerDown to re-enable interrupt
+            byte yControlByte = (byte)StartBit | (byte)MultiplexerChannel.Y
+                                              | (byte)ConversionMode.Bits12
+                                              | (byte)ReferenceSelectMode.DoubleEnded
+                                              | (byte)PowerMode.PowerDown;
+
+            // Fill write buffer with overlapped pattern: control, 0, control, 0, control, 0, control, 0, 0
+            writeBuffer[0] = z1ControlByte;  // Z1 control
+            writeBuffer[1] = 0;              // padding
+            writeBuffer[2] = z2ControlByte;  // Z2 control (while reading Z1)
+            writeBuffer[3] = 0;              // padding
+            writeBuffer[4] = xControlByte;   // X control (while reading Z2)
+            writeBuffer[5] = 0;              // padding
+            writeBuffer[6] = yControlByte;   // Y control (while reading X)
+            writeBuffer[7] = 0;              // padding for Y read
+            writeBuffer[8] = 0;              // padding for Y read
+
+            // Single SPI transaction for all overlapped measurements
+            _spiDevice.TransferFullDuplex(writeBuffer, readBuffer);
+
+            // Extract values from overlapped read buffer
+            // Skip first byte (dummy), then read pairs
+            var Z1 = ((int)readBuffer[1]) * 256 + readBuffer[2];  // skip[0], read[1,2]
+            var Z2 = ((int)readBuffer[3]) * 256 + readBuffer[4];  // skip[2], read[3,4] 
+            var X = ((int)readBuffer[5]) * 256 + readBuffer[6];   // skip[4], read[5,6]
+            var Y = ((int)readBuffer[7]) * 256 + readBuffer[8];   // skip[6], read[7,8]
+
+            Z2 = Z2 == 0 ? 1 : Z2;
+            //Got this from the datasheet but might not be correct
+            var weight = (X / 4096) * ((Z1 / Z2) - 1);
+
+            //Scale the X and Y values to the screen size
+            var xScaled = (((X >> 3) & maxConversion) * _xMax) / maxConversion;
+            var yScaled = (((Y >> 3) & maxConversion) * _yMax) / maxConversion;
+
+            return new Point() { Weight = weight, X = xScaled, Y = yScaled };
+        }
+
+        public void Dispose()
+        {
+            if (!_disposedValue)
+            {
+                _spiDevice?.Dispose();
+                _disposedValue = true;
+            }
+
+            GC.SuppressFinalize(this);
+        }
+
+    }
+}

--- a/devices/XPT2046/XPT2046.nfproj
+++ b/devices/XPT2046/XPT2046.nfproj
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="Current" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<Import Project="packages\Nerdbank.GitVersioning.3.7.115\build\Nerdbank.GitVersioning.props" Condition="Exists('packages\Nerdbank.GitVersioning.3.7.115\build\Nerdbank.GitVersioning.props')" />
+	<PropertyGroup Label="Globals">
+    <NanoFrameworkProjectSystemPath>$(MSBuildExtensionsPath)\nanoFramework\v1.0\</NanoFrameworkProjectSystemPath>
+  </PropertyGroup>
+  <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.Default.props" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.Default.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectTypeGuids>{11A8DD76-328B-46DF-9F39-F559912D0360};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ProjectGuid>bc80a2e4-00d8-483d-84b8-3b8f37950dfe</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <RootNamespace>Iot.Device.XPT2046</RootNamespace>
+    <AssemblyName>Iot.Device.XPT2046</AssemblyName>
+    <TargetFrameworkVersion>v1.0</TargetFrameworkVersion>
+    <AutoGenerateBindingRedirects>false</AutoGenerateBindingRedirects>
+	<DocumentationFile>bin\$(Configuration)\Iot.Device.XPT2046.xml</DocumentationFile>
+    <NuGetAudit>true</NuGetAudit>
+    <NuGetAuditMode>direct</NuGetAuditMode>
+    <NuGetAuditLevel>low</NuGetAuditLevel>
+  </PropertyGroup>
+  <PropertyGroup>
+	  <SignAssembly>true</SignAssembly>
+  </PropertyGroup>
+  <PropertyGroup>
+	  <AssemblyOriginatorKeyFile>..\key.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
+  <PropertyGroup>
+	  <DelaySign>false</DelaySign>
+  </PropertyGroup>
+  <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.props" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.props')" />
+  <ItemGroup>
+    <Compile Include="Point.cs" />
+    <Compile Include="XPT2046.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+    <None Include="XPT2046.nuspec" />
+    <None Include="README.md" />
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="mscorlib">
+      <HintPath>packages\nanoFramework.CoreLibrary.1.17.11\lib\mscorlib.dll</HintPath>
+    </Reference>
+    <Reference Include="nanoFramework.Runtime.Events">
+      <HintPath>packages\nanoFramework.Runtime.Events.1.11.32\lib\nanoFramework.Runtime.Events.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Device.Gpio">
+      <HintPath>packages\nanoFramework.System.Device.Gpio.1.1.57\lib\System.Device.Gpio.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Device.Spi">
+      <HintPath>packages\nanoFramework.System.Device.Spi.1.3.82\lib\System.Device.Spi.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.CSharp.targets" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.CSharp.targets')" />
+  <ProjectExtensions>
+    <ProjectCapabilities>
+      <ProjectConfigurationsDeclaredAsItems />
+    </ProjectCapabilities>
+  </ProjectExtensions>
+</Project>

--- a/devices/XPT2046/XPT2046.nuspec
+++ b/devices/XPT2046/XPT2046.nuspec
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
+  <metadata>
+    <id>nanoFramework.Iot.Device.XPT2046</id>
+    <version>0.0.2</version>
+    <title>nanoFramework.Iot.Device.XPT2046</title>
+    <authors>nanoFramework project contributors</authors>
+    <owners>nanoFramework project contributors</owners>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <license type="expression">MIT</license>
+    <projectUrl>https://github.com/nanoframework/nanoFramework.IoT.Device</projectUrl>
+    <iconUrl>https://github.com/nanoframework/Home/blob/main/resources/logo/nanoFramework-repo-logo.png</iconUrl>
+    <description>This package includes the nanoFramework.Iot.Device.XPT2046 assembly for .NET nanoFramework C# projects.
+
+XPT2046 - Touch screen controller
+
+The XPT2046 from XPTEK is a 4-wire resistive touch screen controller that incorporates a 12-bit 125 kHz successive approximation register type A/D converter. The XPT2046 can detect the pressed screen location by performing two A/D conversions. As well as the location, the XPT2046 also measures touch screen pressure.
+
+Communication is via the SPI bus which can communicate at maximum speed of 2Mhz and uses Mode 0 for the clock polarity/phase setting.</description>
+    <releaseNotes>
+Initial release of XPT2046 touch screen controller driver for nanoFramework.
+    </releaseNotes>
+    <copyright>Copyright (c) .NET Foundation and Contributors</copyright>
+    <tags>nanoFramework C# csharp netmf netnf XPT2046 Touch Screen Controller SPI Resistive</tags>
+    <dependencies>
+      <group targetFramework=".NETnanoFramework1.0">
+        <dependency id="nanoFramework.CoreLibrary" version="1.17.11" />
+        <dependency id="nanoFramework.Runtime.Events" version="1.11.32" />
+        <dependency id="nanoFramework.System.Device.Gpio" version="1.1.57" />
+        <dependency id="nanoFramework.System.Device.Spi" version="1.3.82" />
+      </group>
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="bin\Release\Iot.Device.XPT2046.dll" target="lib\Iot.Device.XPT2046.dll" />
+    <file src="bin\Release\Iot.Device.XPT2046.pdb" target="lib\Iot.Device.XPT2046.pdb" />
+    <file src="bin\Release\Iot.Device.XPT2046.pdbx" target="lib\Iot.Device.XPT2046.pdbx" />
+    <file src="bin\Release\Iot.Device.XPT2046.pe" target="lib\Iot.Device.XPT2046.pe" />
+    <file src="bin\Release\Iot.Device.XPT2046.xml" target="lib\Iot.Device.XPT2046.xml" />
+    <file src="README.md" target="README.md" />
+    <file src="..\..\assets\nf-logo.png" target="images" />
+    <file src="..\..\LICENSE.md" target="" />
+  </files>
+</package>

--- a/devices/XPT2046/XPT2046.sln
+++ b/devices/XPT2046/XPT2046.sln
@@ -1,0 +1,27 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.14.36221.1
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{11A8DD76-328B-46DF-9F39-F559912D0360}") = "XPT2046", "XPT2046.nfproj", "{BC80A2E4-00D8-483D-84B8-3B8F37950DFE}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{BC80A2E4-00D8-483D-84B8-3B8F37950DFE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BC80A2E4-00D8-483D-84B8-3B8F37950DFE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BC80A2E4-00D8-483D-84B8-3B8F37950DFE}.Debug|Any CPU.Deploy.0 = Debug|Any CPU
+		{BC80A2E4-00D8-483D-84B8-3B8F37950DFE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BC80A2E4-00D8-483D-84B8-3B8F37950DFE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BC80A2E4-00D8-483D-84B8-3B8F37950DFE}.Release|Any CPU.Deploy.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {4A350608-DBCF-4618-9F2B-3AC631E05794}
+	EndGlobalSection
+EndGlobal

--- a/devices/XPT2046/category.txt
+++ b/devices/XPT2046/category.txt
@@ -1,0 +1,2 @@
+proximity
+touch

--- a/devices/XPT2046/packages.config
+++ b/devices/XPT2046/packages.config
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="nanoFramework.CoreLibrary" version="1.17.11" targetFramework="netnano1.0" />
+  <package id="nanoFramework.Runtime.Events" version="1.11.32" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Device.Gpio" version="1.1.57" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Device.Spi" version="1.3.82" targetFramework="netnano1.0" />
+  <package id="Nerdbank.GitVersioning" version="3.7.115" targetFramework="netnano1.0" developmentDependency="true" />
+</packages>

--- a/devices/XPT2046/version.json
+++ b/devices/XPT2046/version.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
+  "version": "0.2",
+  "semVer1NumericIdentifierPadding": 3,
+  "nuGetPackageVersion": {
+    "semVer": 0.2
+  },
+  "publicReleaseRefSpec": [
+    "^refs/heads/develop$",
+    "^refs/heads/main$",
+    "^refs/heads/v\\d+(?:\\.\\d+)?$"
+  ],
+  "cloudBuild": {
+    "setAllVariables": true
+  }
+}


### PR DESCRIPTION
<!--- In the TITLE (↑↑↑↑ above ↑↑↑↑ **NOT HERE**) provide a general, short summary of your changes -->
<!--- Please DO NOT use references to other PR's or issues -->

## Description
A driver for interacting with the XPT2046 resistive touch screen. 

## Motivation and Context
The SPI protocol used by this driver is quite complex and typical developers just want the X and Y values of the touch. 
Created by referring to the datasheet and drivers in other languages.
Based the API on other touch controllers already in the repo such as the CHSC6540 and Ft6xx6x

## How Has This Been Tested?
Ran this on an ESP32 based board which has a touch screen built in. Ensured that different touches produced outputs that were proportional to the position.

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ X ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [ ] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ X ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [ X ] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ X ] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.

