### PR TITLE
Add PAJ7620 gesture sensor

### DIFF
--- a/devices/Paj7620/Gesture.cs
+++ b/devices/Paj7620/Gesture.cs
@@ -1,0 +1,66 @@
+﻿//
+// Copyright (c) 2017 The nanoFramework project contributors
+// See LICENSE file in the project root for full license information.
+//
+
+using System;
+
+namespace Iot.Device.Paj7620
+{
+    /// <summary>
+    /// Gestures recognized by the PAJ7620 sensor.
+    /// </summary>
+    [Flags]
+    public enum Gesture
+    {
+        /// <summary>
+        /// No gesture detected.
+        /// </summary>
+        None = 0,
+
+        /// <summary>
+        /// Upward gesture.
+        /// </summary>
+        Up = 0x01,
+
+        /// <summary>
+        /// Downward gesture.
+        /// </summary>
+        Down = 0x02,
+
+        /// <summary>
+        /// Left gesture.
+        /// </summary>
+        Left = 0x04,
+
+        /// <summary>
+        /// Right gesture.
+        /// </summary>
+        Right = 0x08,
+
+        /// <summary>
+        /// Forward gesture.
+        /// </summary>
+        Forward = 0x10,
+
+        /// <summary>
+        /// Backward gesture.
+        /// </summary>
+        Backward = 0x20,
+
+        /// <summary>
+        /// Clockwise rotation gesture.
+        /// </summary>
+        Clockwise = 0x40,
+
+        /// <summary>
+        /// Counter-clockwise rotation gesture.
+        /// </summary>
+        CounterClockwise = 0x80,
+
+        /// <summary>
+        /// Wave gesture.
+        /// </summary>
+        Wave = 0x100,
+    }
+}

--- a/devices/Paj7620/Gesture.cs
+++ b/devices/Paj7620/Gesture.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) 2017 The nanoFramework project contributors
+﻿// Copyright (c) 2017 The nanoFramework project contributors
 // See LICENSE file in the project root for full license information.
-//
 
 using System;
 

--- a/devices/Paj7620/Paj7620.cs
+++ b/devices/Paj7620/Paj7620.cs
@@ -14,19 +14,19 @@ namespace Iot.Device.Paj7620
     /// <summary>
     /// Gestures recognized by the PAJ7620 sensor.
     /// </summary>
+    [Flags]
     public enum Gesture
     {
-        /// <summary>No gesture detected.</summary>
         None = 0,
-        Up,
-        Down,
-        Left,
-        Right,
-        Forward,
-        Backward,
-        Clockwise,
-        CounterClockwise,
-        Wave,
+        Up = 0x01,
+        Down = 0x02,
+        Left = 0x04,
+        Right = 0x08,
+        Forward = 0x10,
+        Backward = 0x20,
+        Clockwise = 0x40,
+        CounterClockwise = 0x80,
+        Wave = 0x100,
     }
 
     /// <summary>
@@ -58,17 +58,6 @@ namespace Iot.Device.Paj7620
         private const byte ExpectedPartIdLow = 0x20;
         private const byte ExpectedPartIdHigh = 0x76;
 
-        // Gesture bit masks from PAJ7620 gesture result registers.
-        private const byte GestureUpFlag = 0x01;
-        private const byte GestureDownFlag = 0x02;
-        private const byte GestureLeftFlag = 0x04;
-        private const byte GestureRightFlag = 0x08;
-        private const byte GestureForwardFlag = 0x10;
-        private const byte GestureBackwardFlag = 0x20;
-        private const byte GestureClockwiseFlag = 0x40;
-        private const byte GestureCounterClockwiseFlag = 0x80;
-        private const byte GestureWaveFlag = 0x01; // from register 0x44
-
         private readonly I2cDevice _i2C;
         private int _gestureDebounceMilliseconds = DefaultGestureDebounceMilliseconds;
         private bool _initialized;
@@ -77,6 +66,9 @@ namespace Iot.Device.Paj7620
         /// Gets or sets the debounce interval, in milliseconds, applied after a detected gesture.
         /// </summary>
         /// <remarks>Set to 0 to disable debounce.</remarks>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// Gesture debounce must be greater than or equal to 0.
+        /// </exception>
         public int GestureDebounceMilliseconds
         {
             get => _gestureDebounceMilliseconds;
@@ -84,7 +76,7 @@ namespace Iot.Device.Paj7620
             {
                 if (value < 0)
                 {
-                    throw new ArgumentOutOfRangeException(nameof(value), "Gesture debounce must be greater than or equal to 0.");
+                    throw new ArgumentOutOfRangeException(nameof(value));
                 }
 
                 _gestureDebounceMilliseconds = value;
@@ -162,6 +154,9 @@ namespace Iot.Device.Paj7620
         /// Creates a new PAJ7620U2 gesture sensor instance.
         /// </summary>
         /// <param name="i2CDevice">I2C device.</param>
+        /// <exception cref="ArgumentNullException">
+        /// PAJ7620 requires a non-null I2C device instance.
+        /// </exception>
         public Paj7620(I2cDevice i2CDevice)
         {
             _i2C = i2CDevice ?? throw new ArgumentNullException(nameof(i2CDevice));
@@ -264,22 +259,15 @@ namespace Iot.Device.Paj7620
 
         private static Gesture DecodeGesture(byte result0, byte result1)
         {
+            Gesture gesture = (Gesture)result0;
+
             // Wave flag is in result register 1.
-            if ((result1 & GestureWaveFlag) != 0)
+            if ((result1 & 0x01) != 0)
             {
-                return Gesture.Wave;
+                gesture |= Gesture.Wave;
             }
 
-            if ((result0 & GestureUpFlag) != 0) return Gesture.Up;
-            if ((result0 & GestureDownFlag) != 0) return Gesture.Down;
-            if ((result0 & GestureLeftFlag) != 0) return Gesture.Left;
-            if ((result0 & GestureRightFlag) != 0) return Gesture.Right;
-            if ((result0 & GestureForwardFlag) != 0) return Gesture.Forward;
-            if ((result0 & GestureBackwardFlag) != 0) return Gesture.Backward;
-            if ((result0 & GestureClockwiseFlag) != 0) return Gesture.Clockwise;
-            if ((result0 & GestureCounterClockwiseFlag) != 0) return Gesture.CounterClockwise;
-
-            return Gesture.None;
+            return gesture;
         }
 
         private void EnsureInitialized()

--- a/devices/Paj7620/Paj7620.cs
+++ b/devices/Paj7620/Paj7620.cs
@@ -37,7 +37,7 @@ namespace Iot.Device.Paj7620
         private const byte ExpectedPartIdLow = 0x20;
         private const byte ExpectedPartIdHigh = 0x76;
 
-        // Init sequence adapted from RevEng_PAJ7620/Seeed reference: https://github.com/Seeed-Studio/Grove_Gesture/tree/master
+        // Init sequence inspired by Seeed reference: https://github.com/Seeed-Studio/Grove_Gesture/tree/master
         // Datasheet: https://files.seeedstudio.com/wiki/Grove_Gesture_V_1.0/res/PAJ7620U2_DS_v1.5_05012022_Confidential.pdf
         // flat [register, value] pairs for memory efficiency on MCUs.
         private static readonly byte[] InitRegisterPairs = new byte[]

--- a/devices/Paj7620/Paj7620.cs
+++ b/devices/Paj7620/Paj7620.cs
@@ -176,12 +176,12 @@ namespace Iot.Device.Paj7620
             }
             catch (Exception ex)
             {
-                throw new IOException("PAJ7620 not responding on I2C bus.", ex);
+                throw new IOException(ex.Message);
             }
 
             if (idHigh != ExpectedPartIdHigh || idLow != ExpectedPartIdLow)
             {
-                throw new IOException($"PAJ7620 error. Expected 0x7620, but got: 0x{idHigh:X2}{idLow:X2}");
+                throw new IOException($"PAJ7620 error. PartID: 0x{idHigh:X2}{idLow:X2} (Expected: 0x7620)");
             }
 
             WriteRegisterPairs(InitRegisterPairs);
@@ -199,7 +199,6 @@ namespace Iot.Device.Paj7620
         /// <returns>True if a valid gesture is available, otherwise false.</returns>
         public bool TryReadGesture(out Gesture gesture)
         {
-            gesture = Gesture.None;
             EnsureInitialized();
 
             try
@@ -232,11 +231,6 @@ namespace Iot.Device.Paj7620
                 gesture = Gesture.None;
                 return false;
             }
-            catch (Exception)
-            {
-                gesture = Gesture.None;
-                return false;
-            }
         }
 
         private static Gesture DecodeGesture(byte result0, byte result1)
@@ -252,14 +246,20 @@ namespace Iot.Device.Paj7620
             return gesture;
         }
 
+        /// <exception cref="InvalidOperationException">
+        /// PAJ7620 is not initialized. Call Initialize() before reading gestures.
+        /// </exception>
         private void EnsureInitialized()
         {
             if (!_initialized)
             {
-                throw new InvalidOperationException("PAJ7620 is not initialized. Call Initialize() before reading gestures.");
+                throw new InvalidOperationException();
             }
         }
 
+        /// <exception cref="InvalidOperationException">
+        /// Initialization data must contain register/value pairs.
+        /// </exception>
         private void WriteRegisterPairs(byte[] registerValuePairs)
         {
             if (registerValuePairs == null || registerValuePairs.Length == 0)
@@ -269,7 +269,7 @@ namespace Iot.Device.Paj7620
 
             if ((registerValuePairs.Length & 0x01) != 0)
             {
-                throw new InvalidOperationException("Initialization data must contain register/value pairs.");
+                throw new InvalidOperationException();
             }
 
             for (int i = 0; i < registerValuePairs.Length; i += 2)
@@ -278,6 +278,9 @@ namespace Iot.Device.Paj7620
             }
         }
 
+        /// <exception cref="IOException">
+        /// PAJ7620 I2C write failed after retries.
+        /// </exception>
         private void WriteByteWithRetry(byte register, byte value)
         {
             SpanByte buffer = new byte[2];
@@ -291,11 +294,11 @@ namespace Iot.Device.Paj7620
                     _i2C.Write(buffer);
                     return;
                 }
-                catch (Exception ex)
+                catch
                 {
                     if (attempt == IoRetries - 1)
                     {
-                        throw new IOException("PAJ7620 I2C write failed after retries.", ex);
+                        throw new IOException();
                     }
 
                     Thread.Sleep(RetryDelayMilliseconds);
@@ -303,6 +306,9 @@ namespace Iot.Device.Paj7620
             }
         }
 
+        /// <exception cref="IOException">
+        /// PAJ7620 I2C read failed after retries.
+        /// </exception>
         private byte ReadByteWithRetry(byte register)
         {
             SpanByte writeBuffer = new byte[] { register };
@@ -315,15 +321,15 @@ namespace Iot.Device.Paj7620
                     _i2C.WriteRead(writeBuffer, readBuffer);
                     return readBuffer[0];
                 }
-                catch (Exception ex)
+                catch
                 {
                     if (attempt == IoRetries - 1)
-                        throw new IOException("PAJ7620 I2C read failed after retries.", ex);
+                        throw new IOException();
 
                     Thread.Sleep(RetryDelayMilliseconds);
                 }
             }
-            throw new IOException("PAJ7620 I2C read failed after retries.");
+            throw new IOException();
         }
 
         /// <inheritdoc/>

--- a/devices/Paj7620/Paj7620.cs
+++ b/devices/Paj7620/Paj7620.cs
@@ -105,6 +105,9 @@ namespace Iot.Device.Paj7620
         };
 
         private readonly I2cDevice _i2C;
+        private readonly byte[] _writePairBuffer = new byte[2];
+        private readonly byte[] _readRegisterBuffer = new byte[1];
+        private readonly byte[] _readValueBuffer = new byte[1];
         private int _gestureDebounceMilliseconds = DefaultGestureDebounceMilliseconds;
         private bool _initialized;
 
@@ -220,7 +223,6 @@ namespace Iot.Device.Paj7620
 
             return gesture != Gesture.None;
         }
-        }
 
         private static Gesture DecodeGesture(byte result0, byte result1)
         {
@@ -284,15 +286,14 @@ namespace Iot.Device.Paj7620
         /// </exception>
         private void WriteByteWithRetry(byte register, byte value)
         {
-            SpanByte buffer = new byte[2];
-            buffer[0] = register;
-            buffer[1] = value;
+            _writePairBuffer[0] = register;
+            _writePairBuffer[1] = value;
 
             for (int attempt = 0; attempt < IoRetries; attempt++)
             {
                 try
                 {
-                    _i2C.Write(buffer);
+                    _i2C.Write(_writePairBuffer);
                     return;
                 }
                 catch
@@ -317,15 +318,14 @@ namespace Iot.Device.Paj7620
         /// </exception>
         private byte ReadByteWithRetry(byte register)
         {
-            SpanByte writeBuffer = new byte[] { register };
-            SpanByte readBuffer = new byte[1];
+            _readRegisterBuffer[0] = register;
 
             for (int attempt = 0; attempt < IoRetries; attempt++)
             {
                 try
                 {
-                    _i2C.WriteRead(writeBuffer, readBuffer);
-                    return readBuffer[0];
+                    _i2C.WriteRead(_readRegisterBuffer, _readValueBuffer);
+                    return _readValueBuffer[0];
                 }
                 catch
                 {

--- a/devices/Paj7620/Paj7620.cs
+++ b/devices/Paj7620/Paj7620.cs
@@ -1,7 +1,5 @@
-//
 // Copyright (c) 2017 The nanoFramework project contributors
 // See LICENSE file in the project root for full license information.
-//
 
 using System;
 using System.Device.I2c;
@@ -30,7 +28,6 @@ namespace Iot.Device.Paj7620
         private const int IoRetries = 3;
         private const int RetryDelayMilliseconds = 2;
 
-
         private const byte RegisterBankSelect = 0xEF;
         private const byte RegisterPartIdLow = 0x00;
         private const byte RegisterPartIdHigh = 0x01;
@@ -39,32 +36,6 @@ namespace Iot.Device.Paj7620
 
         private const byte ExpectedPartIdLow = 0x20;
         private const byte ExpectedPartIdHigh = 0x76;
-
-        private readonly I2cDevice _i2C;
-        private int _gestureDebounceMilliseconds = DefaultGestureDebounceMilliseconds;
-        private bool _initialized;
-
-        /// <summary>
-        /// Gets or sets the debounce interval, in milliseconds, applied after a detected gesture.
-        /// </summary>
-        /// <remarks>Set to 0 to disable debounce.</remarks>
-        /// <exception cref="ArgumentOutOfRangeException">
-        /// Gesture debounce must be greater than or equal to 0.
-        /// </exception>
-        public int GestureDebounceMilliseconds
-        {
-            get => _gestureDebounceMilliseconds;
-            set
-            {
-                if (value < 0)
-                {
-                    throw new ArgumentOutOfRangeException(nameof(value));
-                }
-
-                _gestureDebounceMilliseconds = value;
-            }
-        }
-
 
         // Init sequence adapted from RevEng_PAJ7620/Seeed reference:
         // flat [register, value] pairs for memory efficiency on MCUs.
@@ -132,8 +103,33 @@ namespace Iot.Device.Paj7620
             0x42, 0x01,
         };
 
+        private readonly I2cDevice _i2C;
+        private int _gestureDebounceMilliseconds = DefaultGestureDebounceMilliseconds;
+        private bool _initialized;
+
         /// <summary>
-        /// Creates a new PAJ7620U2 gesture sensor instance.
+        /// Gets or sets the debounce interval, in milliseconds, applied after a detected gesture.
+        /// </summary>
+        /// <remarks>Set to 0 to disable debounce.</remarks>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// Gesture debounce must be greater than or equal to 0.
+        /// </exception>
+        public int GestureDebounceMilliseconds
+        {
+            get => _gestureDebounceMilliseconds;
+            set
+            {
+                if (value < 0)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(value));
+                }
+
+                _gestureDebounceMilliseconds = value;
+            }
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Paj7620"/> class.
         /// </summary>
         /// <param name="i2CDevice">I2C device.</param>
         /// <exception cref="ArgumentNullException">
@@ -151,7 +147,7 @@ namespace Iot.Device.Paj7620
         {
             Thread.Sleep(500);
 
-            //Wake up call
+            // Wake up call
             try
             {
                 _i2C.WriteByte(0x00);
@@ -160,7 +156,6 @@ namespace Iot.Device.Paj7620
             {
                 // Ignore. Errors will be caught during ID read. 
             }
-
 
             Thread.Sleep(10);
 
@@ -246,6 +241,9 @@ namespace Iot.Device.Paj7620
             return gesture;
         }
 
+        /// <summary>
+        /// Validates that the sensor has been initialized.
+        /// </summary>
         /// <exception cref="InvalidOperationException">
         /// PAJ7620 is not initialized. Call Initialize() before reading gestures.
         /// </exception>
@@ -257,6 +255,10 @@ namespace Iot.Device.Paj7620
             }
         }
 
+        /// <summary>
+        /// Writes register/value pairs to the sensor.
+        /// </summary>
+        /// <param name="registerValuePairs">Flat register/value byte pairs to write.</param>
         /// <exception cref="InvalidOperationException">
         /// Initialization data must contain register/value pairs.
         /// </exception>
@@ -278,6 +280,11 @@ namespace Iot.Device.Paj7620
             }
         }
 
+        /// <summary>
+        /// Writes a byte value to the specified register with retry logic.
+        /// </summary>
+        /// <param name="register">Register address to write.</param>
+        /// <param name="value">Byte value to write.</param>
         /// <exception cref="IOException">
         /// PAJ7620 I2C write failed after retries.
         /// </exception>
@@ -306,6 +313,11 @@ namespace Iot.Device.Paj7620
             }
         }
 
+        /// <summary>
+        /// Reads a byte value from the specified register with retry logic.
+        /// </summary>
+        /// <param name="register">Register address to read.</param>
+        /// <returns>The byte value read from the register.</returns>
         /// <exception cref="IOException">
         /// PAJ7620 I2C read failed after retries.
         /// </exception>
@@ -324,11 +336,14 @@ namespace Iot.Device.Paj7620
                 catch
                 {
                     if (attempt == IoRetries - 1)
+                    {
                         throw new IOException();
+                    }
 
                     Thread.Sleep(RetryDelayMilliseconds);
                 }
             }
+
             throw new IOException();
         }
 

--- a/devices/Paj7620/Paj7620.cs
+++ b/devices/Paj7620/Paj7620.cs
@@ -12,24 +12,6 @@ using System.Threading;
 namespace Iot.Device.Paj7620
 {
     /// <summary>
-    /// Gestures recognized by the PAJ7620 sensor.
-    /// </summary>
-    [Flags]
-    public enum Gesture
-    {
-        None = 0,
-        Up = 0x01,
-        Down = 0x02,
-        Left = 0x04,
-        Right = 0x08,
-        Forward = 0x10,
-        Backward = 0x20,
-        Clockwise = 0x40,
-        CounterClockwise = 0x80,
-        Wave = 0x100,
-    }
-
-    /// <summary>
     /// PAJ7620/PAJ7620U2 gesture sensor binding.
     /// </summary>
     [Interface("PAJ7620U2 gesture sensor")]

--- a/devices/Paj7620/Paj7620.cs
+++ b/devices/Paj7620/Paj7620.cs
@@ -197,36 +197,29 @@ namespace Iot.Device.Paj7620
         {
             EnsureInitialized();
 
-            try
+            byte result0 = ReadByteWithRetry(RegisterGestureResult0);
+            byte result1 = ReadByteWithRetry(RegisterGestureResult1);
+
+            // Clear latched flags by reading again.
+            _ = ReadByteWithRetry(RegisterGestureResult0);
+            _ = ReadByteWithRetry(RegisterGestureResult1);
+
+            gesture = DecodeGesture(result0, result1);
+
+            if (gesture != Gesture.None)
             {
-                byte result0 = ReadByteWithRetry(RegisterGestureResult0);
-                byte result1 = ReadByteWithRetry(RegisterGestureResult1);
-
-                // Clear latched flags by reading again.
-                _ = ReadByteWithRetry(RegisterGestureResult0);
-                _ = ReadByteWithRetry(RegisterGestureResult1);
-
-                gesture = DecodeGesture(result0, result1);
-
-                if (gesture != Gesture.None)
+                if (GestureDebounceMilliseconds > 0)
                 {
-                    if (GestureDebounceMilliseconds > 0)
-                    {
-                        Thread.Sleep(GestureDebounceMilliseconds);
-                    }
-
-                    // Clear any follow-up movement flags after debounce window.
-                    _ = ReadByteWithRetry(RegisterGestureResult0);
-                    _ = ReadByteWithRetry(RegisterGestureResult1);
+                    Thread.Sleep(GestureDebounceMilliseconds);
                 }
 
-                return gesture != Gesture.None;
+                // Clear any follow-up movement flags after debounce window.
+                _ = ReadByteWithRetry(RegisterGestureResult0);
+                _ = ReadByteWithRetry(RegisterGestureResult1);
             }
-            catch (IOException)
-            {
-                gesture = Gesture.None;
-                return false;
-            }
+
+            return gesture != Gesture.None;
+        }
         }
 
         private static Gesture DecodeGesture(byte result0, byte result1)

--- a/devices/Paj7620/Paj7620.cs
+++ b/devices/Paj7620/Paj7620.cs
@@ -37,7 +37,8 @@ namespace Iot.Device.Paj7620
         private const byte ExpectedPartIdLow = 0x20;
         private const byte ExpectedPartIdHigh = 0x76;
 
-        // Init sequence adapted from RevEng_PAJ7620/Seeed reference:
+        // Init sequence adapted from RevEng_PAJ7620/Seeed reference: https://github.com/Seeed-Studio/Grove_Gesture/tree/master
+        // Datasheet: https://files.seeedstudio.com/wiki/Grove_Gesture_V_1.0/res/PAJ7620U2_DS_v1.5_05012022_Confidential.pdf
         // flat [register, value] pairs for memory efficiency on MCUs.
         private static readonly byte[] InitRegisterPairs = new byte[]
         {

--- a/devices/Paj7620/Paj7620.cs
+++ b/devices/Paj7620/Paj7620.cs
@@ -1,0 +1,365 @@
+//
+// Copyright (c) 2017 The nanoFramework project contributors
+// See LICENSE file in the project root for full license information.
+//
+
+using System;
+using System.Device.I2c;
+using System.Device.Model;
+using System.IO;
+using System.Threading;
+
+namespace Iot.Device.Paj7620
+{
+    /// <summary>
+    /// Gestures recognized by the PAJ7620 sensor.
+    /// </summary>
+    public enum Gesture
+    {
+        /// <summary>No gesture detected.</summary>
+        None = 0,
+        Up,
+        Down,
+        Left,
+        Right,
+        Forward,
+        Backward,
+        Clockwise,
+        CounterClockwise,
+        Wave,
+    }
+
+    /// <summary>
+    /// PAJ7620/PAJ7620U2 gesture sensor binding.
+    /// </summary>
+    [Interface("PAJ7620U2 gesture sensor")]
+    public sealed class Paj7620 : IDisposable
+    {
+        /// <summary>
+        /// Default I2C address.
+        /// </summary>
+        public const int DefaultI2CAddress = 0x73;
+
+        /// <summary>
+        /// Default debounce interval, in milliseconds, used to filter out rapid consecutive gesture inputs.
+        /// </summary>
+        public const int DefaultGestureDebounceMilliseconds = 500;
+
+        private const int IoRetries = 3;
+        private const int RetryDelayMilliseconds = 2;
+
+
+        private const byte RegisterBankSelect = 0xEF;
+        private const byte RegisterPartIdLow = 0x00;
+        private const byte RegisterPartIdHigh = 0x01;
+        private const byte RegisterGestureResult0 = 0x43;
+        private const byte RegisterGestureResult1 = 0x44;
+
+        private const byte ExpectedPartIdLow = 0x20;
+        private const byte ExpectedPartIdHigh = 0x76;
+
+        // Gesture bit masks from PAJ7620 gesture result registers.
+        private const byte GestureUpFlag = 0x01;
+        private const byte GestureDownFlag = 0x02;
+        private const byte GestureLeftFlag = 0x04;
+        private const byte GestureRightFlag = 0x08;
+        private const byte GestureForwardFlag = 0x10;
+        private const byte GestureBackwardFlag = 0x20;
+        private const byte GestureClockwiseFlag = 0x40;
+        private const byte GestureCounterClockwiseFlag = 0x80;
+        private const byte GestureWaveFlag = 0x01; // from register 0x44
+
+        private readonly I2cDevice _i2C;
+        private int _gestureDebounceMilliseconds = DefaultGestureDebounceMilliseconds;
+        private bool _initialized;
+
+        /// <summary>
+        /// Gets or sets the debounce interval, in milliseconds, applied after a detected gesture.
+        /// </summary>
+        /// <remarks>Set to 0 to disable debounce.</remarks>
+        public int GestureDebounceMilliseconds
+        {
+            get => _gestureDebounceMilliseconds;
+            set
+            {
+                if (value < 0)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(value), "Gesture debounce must be greater than or equal to 0.");
+                }
+
+                _gestureDebounceMilliseconds = value;
+            }
+        }
+
+
+        // Init sequence adapted from RevEng_PAJ7620/Seeed reference:
+        // flat [register, value] pairs for memory efficiency on MCUs.
+        private static readonly byte[] InitRegisterPairs = new byte[]
+        {
+            // Bank 0
+            0xEF, 0x00,
+            0x41, 0x00, // disable interrupts for first 8 gestures during setup
+            0x42, 0x00, // disable wave interrupt during setup
+            0x37, 0x07,
+            0x38, 0x17,
+            0x39, 0x06,
+            0x42, 0x01,
+            0x46, 0x2D,
+            0x47, 0x0F,
+            0x48, 0x3C,
+            0x49, 0x00,
+            0x4A, 0x1E,
+            0x4C, 0x22,
+            0x51, 0x10,
+            0x5E, 0x10,
+            0x60, 0x27,
+            0x80, 0x42,
+            0x81, 0x44,
+            0x82, 0x04,
+            0x8B, 0x01,
+            0x90, 0x06,
+            0x95, 0x0A,
+            0x96, 0x0C,
+            0x97, 0x05,
+            0x9A, 0x14,
+            0x9C, 0x3F,
+            0xA5, 0x19,
+            0xCC, 0x19,
+            0xCD, 0x0B,
+            0xCE, 0x13,
+            0xCF, 0x64,
+            0xD0, 0x21,
+
+            // Bank 1
+            0xEF, 0x01,
+            0x02, 0x0F,
+            0x03, 0x10,
+            0x04, 0x02,
+            0x25, 0x01,
+            0x27, 0x39,
+            0x28, 0x7F,
+            0x29, 0x08,
+            0x3E, 0xFF,
+            0x5E, 0x3D,
+            0x65, 0x96, // idle timing, commonly used for normal mode
+            0x67, 0x97,
+            0x69, 0xCD,
+            0x6A, 0x01,
+            0x6D, 0x2C,
+            0x6E, 0x01,
+            0x72, 0x01, // operation enable
+            0x73, 0x35,
+            0x74, 0x00, // gesture mode
+            0x77, 0x01,
+
+            // Return to Bank 0 and re-enable gesture interrupts
+            0xEF, 0x00,
+            0x41, 0xFF,
+            0x42, 0x01,
+        };
+
+        /// <summary>
+        /// Creates a new PAJ7620U2 gesture sensor instance.
+        /// </summary>
+        /// <param name="i2CDevice">I2C device.</param>
+        public Paj7620(I2cDevice i2CDevice)
+        {
+            _i2C = i2CDevice ?? throw new ArgumentNullException(nameof(i2CDevice));
+        }
+
+        /// <summary>
+        /// Initializes the sensor and validates the expected device ID.
+        /// </summary>
+        public void Initialize()
+        {
+            Thread.Sleep(500);
+
+            //Wake up call
+            try
+            {
+                _i2C.WriteByte(0x00);
+            }
+            catch
+            {
+                // Ignore. Errors will be caught during ID read. 
+            }
+
+
+            Thread.Sleep(10);
+
+            // Park on Bank 0 before reading part ID.
+            WriteByteWithRetry(RegisterBankSelect, 0x00);
+
+            byte idHigh;
+            byte idLow;
+            try
+            {
+                idHigh = ReadByteWithRetry(RegisterPartIdHigh);
+                idLow = ReadByteWithRetry(RegisterPartIdLow);
+            }
+            catch (Exception ex)
+            {
+                throw new IOException("PAJ7620 not responding on I2C bus.", ex);
+            }
+
+            if (idHigh != ExpectedPartIdHigh || idLow != ExpectedPartIdLow)
+            {
+                throw new IOException($"PAJ7620 error. Expected 0x7620, but got: 0x{idHigh:X2}{idLow:X2}");
+            }
+
+            WriteRegisterPairs(InitRegisterPairs);
+
+            // Ensure reads happen from Bank 0.
+            WriteByteWithRetry(RegisterBankSelect, 0x00);
+
+            _initialized = true;
+        }
+
+        /// <summary>
+        /// Tries to read the current gesture.
+        /// </summary>
+        /// <param name="gesture">Detected gesture or <see cref="Gesture.None"/>.</param>
+        /// <returns>True if a valid gesture is available, otherwise false.</returns>
+        public bool TryReadGesture(out Gesture gesture)
+        {
+            gesture = Gesture.None;
+            EnsureInitialized();
+
+            try
+            {
+                byte result0 = ReadByteWithRetry(RegisterGestureResult0);
+                byte result1 = ReadByteWithRetry(RegisterGestureResult1);
+
+                // Clear latched flags by reading again.
+                _ = ReadByteWithRetry(RegisterGestureResult0);
+                _ = ReadByteWithRetry(RegisterGestureResult1);
+
+                gesture = DecodeGesture(result0, result1);
+
+                if (gesture != Gesture.None)
+                {
+                    if (GestureDebounceMilliseconds > 0)
+                    {
+                        Thread.Sleep(GestureDebounceMilliseconds);
+                    }
+
+                    // Clear any follow-up movement flags after debounce window.
+                    _ = ReadByteWithRetry(RegisterGestureResult0);
+                    _ = ReadByteWithRetry(RegisterGestureResult1);
+                }
+
+                return gesture != Gesture.None;
+            }
+            catch (IOException)
+            {
+                gesture = Gesture.None;
+                return false;
+            }
+            catch (Exception)
+            {
+                gesture = Gesture.None;
+                return false;
+            }
+        }
+
+        private static Gesture DecodeGesture(byte result0, byte result1)
+        {
+            // Wave flag is in result register 1.
+            if ((result1 & GestureWaveFlag) != 0)
+            {
+                return Gesture.Wave;
+            }
+
+            if ((result0 & GestureUpFlag) != 0) return Gesture.Up;
+            if ((result0 & GestureDownFlag) != 0) return Gesture.Down;
+            if ((result0 & GestureLeftFlag) != 0) return Gesture.Left;
+            if ((result0 & GestureRightFlag) != 0) return Gesture.Right;
+            if ((result0 & GestureForwardFlag) != 0) return Gesture.Forward;
+            if ((result0 & GestureBackwardFlag) != 0) return Gesture.Backward;
+            if ((result0 & GestureClockwiseFlag) != 0) return Gesture.Clockwise;
+            if ((result0 & GestureCounterClockwiseFlag) != 0) return Gesture.CounterClockwise;
+
+            return Gesture.None;
+        }
+
+        private void EnsureInitialized()
+        {
+            if (!_initialized)
+            {
+                throw new InvalidOperationException("PAJ7620 is not initialized. Call Initialize() before reading gestures.");
+            }
+        }
+
+        private void WriteRegisterPairs(byte[] registerValuePairs)
+        {
+            if (registerValuePairs == null || registerValuePairs.Length == 0)
+            {
+                return;
+            }
+
+            if ((registerValuePairs.Length & 0x01) != 0)
+            {
+                throw new InvalidOperationException("Initialization data must contain register/value pairs.");
+            }
+
+            for (int i = 0; i < registerValuePairs.Length; i += 2)
+            {
+                WriteByteWithRetry(registerValuePairs[i], registerValuePairs[i + 1]);
+            }
+        }
+
+        private void WriteByteWithRetry(byte register, byte value)
+        {
+            SpanByte buffer = new byte[2];
+            buffer[0] = register;
+            buffer[1] = value;
+
+            for (int attempt = 0; attempt < IoRetries; attempt++)
+            {
+                try
+                {
+                    _i2C.Write(buffer);
+                    return;
+                }
+                catch (Exception ex)
+                {
+                    if (attempt == IoRetries - 1)
+                    {
+                        throw new IOException("PAJ7620 I2C write failed after retries.", ex);
+                    }
+
+                    Thread.Sleep(RetryDelayMilliseconds);
+                }
+            }
+        }
+
+        private byte ReadByteWithRetry(byte register)
+        {
+            SpanByte writeBuffer = new byte[] { register };
+            SpanByte readBuffer = new byte[1];
+
+            for (int attempt = 0; attempt < IoRetries; attempt++)
+            {
+                try
+                {
+                    _i2C.WriteRead(writeBuffer, readBuffer);
+                    return readBuffer[0];
+                }
+                catch (Exception ex)
+                {
+                    if (attempt == IoRetries - 1)
+                        throw new IOException("PAJ7620 I2C read failed after retries.", ex);
+
+                    Thread.Sleep(RetryDelayMilliseconds);
+                }
+            }
+            throw new IOException("PAJ7620 I2C read failed after retries.");
+        }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            _i2C?.Dispose();
+        }
+    }
+}

--- a/devices/Paj7620/Paj7620.nfproj
+++ b/devices/Paj7620/Paj7620.nfproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="Current" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="packages\Nerdbank.GitVersioning.3.9.50\build\Nerdbank.GitVersioning.props" Condition="Exists('packages\Nerdbank.GitVersioning.3.9.50\build\Nerdbank.GitVersioning.props')" />
   <PropertyGroup Label="Globals">
@@ -19,6 +19,7 @@
     <DocumentationFile>bin\$(Configuration)\Iot.Device.Paj7620.xml</DocumentationFile>
     <LangVersion>9.0</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <StyleCopTreatErrorsAsWarnings>false</StyleCopTreatErrorsAsWarnings>
   </PropertyGroup>
   <PropertyGroup>
     <SignAssembly>true</SignAssembly>
@@ -33,17 +34,18 @@
   <ItemGroup>
     <Reference Include="mscorlib, Version=1.17.11.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>packages\nanoFramework.CoreLibrary.1.17.11\lib\mscorlib.dll</HintPath>
+      <SpecificVersion>True</SpecificVersion>
     </Reference>
-    <Reference Include="System.Device.I2c, Version=1.1.29.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+    <Reference Include="System.Device.I2c">
       <HintPath>packages\nanoFramework.System.Device.I2c.1.1.29\lib\System.Device.I2c.dll</HintPath>
     </Reference>
-    <Reference Include="System.Device.Model, Version=1.2.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+    <Reference Include="System.Device.Model">
       <HintPath>packages\nanoFramework.System.Device.Model.1.2.862\lib\System.Device.Model.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <None Include="Paj7620.nuspec" />
     <None Include="packages.config" />
+    <None Include="Paj7620.nuspec" />
     <Compile Include="Gesture.cs" />
     <Compile Include="Paj7620.cs" />
     <None Include="README.md" />
@@ -54,6 +56,7 @@
   </ItemGroup>
   <ItemGroup>
     <Content Include="category.txt" />
+    <Content Include="packages.lock.json" />
     <Content Include="version.json" />
   </ItemGroup>
   <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.CSharp.targets" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.CSharp.targets')" />
@@ -70,4 +73,11 @@
     <Error Condition="!Exists('packages\Nerdbank.GitVersioning.3.9.50\build\Nerdbank.GitVersioning.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Nerdbank.GitVersioning.3.9.50\build\Nerdbank.GitVersioning.targets'))" />
   </Target>
   <Import Project="packages\Nerdbank.GitVersioning.3.9.50\build\Nerdbank.GitVersioning.targets" Condition="Exists('packages\Nerdbank.GitVersioning.3.9.50\build\Nerdbank.GitVersioning.targets')" />
+  <Import Project="packages\StyleCop.MSBuild.6.2.0\build\StyleCop.MSBuild.targets" Condition="Exists('packages\StyleCop.MSBuild.6.2.0\build\StyleCop.MSBuild.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('packages\StyleCop.MSBuild.6.2.0\build\StyleCop.MSBuild.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\StyleCop.MSBuild.6.2.0\build\StyleCop.MSBuild.targets'))" />
+  </Target>
 </Project>

--- a/devices/Paj7620/Paj7620.nfproj
+++ b/devices/Paj7620/Paj7620.nfproj
@@ -1,0 +1,72 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="Current" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="packages\Nerdbank.GitVersioning.3.9.50\build\Nerdbank.GitVersioning.props" Condition="Exists('packages\Nerdbank.GitVersioning.3.9.50\build\Nerdbank.GitVersioning.props')" />
+  <PropertyGroup Label="Globals">
+    <NanoFrameworkProjectSystemPath>$(MSBuildExtensionsPath)\nanoFramework\v1.0\</NanoFrameworkProjectSystemPath>
+  </PropertyGroup>
+  <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.Default.props" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.Default.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectTypeGuids>{11A8DD76-328B-46DF-9F39-F559912D0360};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ProjectGuid>{E79903D4-4F7C-4FB5-8078-086CD3B3252B}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <RootNamespace>Iot.Device.Paj7620</RootNamespace>
+    <AssemblyName>Iot.Device.Paj7620</AssemblyName>
+    <TargetFrameworkVersion>v1.0</TargetFrameworkVersion>
+    <DocumentationFile>bin\$(Configuration)\Iot.Device.Paj7620.xml</DocumentationFile>
+    <LangVersion>9.0</LangVersion>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <PropertyGroup>
+    <SignAssembly>true</SignAssembly>
+  </PropertyGroup>
+  <PropertyGroup>
+    <AssemblyOriginatorKeyFile>..\key.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DelaySign>false</DelaySign>
+  </PropertyGroup>
+  <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.props" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.props')" />
+  <ItemGroup>
+    <Reference Include="mscorlib, Version=1.17.11.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>packages\nanoFramework.CoreLibrary.1.17.11\lib\mscorlib.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Device.I2c, Version=1.1.29.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>packages\nanoFramework.System.Device.I2c.1.1.29\lib\System.Device.I2c.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Device.Model, Version=1.2.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>packages\nanoFramework.System.Device.Model.1.2.862\lib\System.Device.Model.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="Paj7620.nuspec" />
+    <None Include="packages.config" />
+    <Compile Include="Paj7620.cs" />
+    <None Include="README.md" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <None Include="*.md" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="category.txt" />
+    <Content Include="version.json" />
+  </ItemGroup>
+  <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.CSharp.targets" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.CSharp.targets')" />
+  <ProjectExtensions>
+    <ProjectCapabilities>
+      <ProjectConfigurationsDeclaredAsItems />
+    </ProjectCapabilities>
+  </ProjectExtensions>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105.The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('packages\Nerdbank.GitVersioning.3.9.50\build\Nerdbank.GitVersioning.props')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Nerdbank.GitVersioning.3.9.50\build\Nerdbank.GitVersioning.props'))" />
+    <Error Condition="!Exists('packages\Nerdbank.GitVersioning.3.9.50\build\Nerdbank.GitVersioning.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Nerdbank.GitVersioning.3.9.50\build\Nerdbank.GitVersioning.targets'))" />
+  </Target>
+  <Import Project="packages\Nerdbank.GitVersioning.3.9.50\build\Nerdbank.GitVersioning.targets" Condition="Exists('packages\Nerdbank.GitVersioning.3.9.50\build\Nerdbank.GitVersioning.targets')" />
+</Project>

--- a/devices/Paj7620/Paj7620.nfproj
+++ b/devices/Paj7620/Paj7620.nfproj
@@ -67,17 +67,12 @@
   </ProjectExtensions>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105.The missing file is {0}.</ErrorText>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('packages\Nerdbank.GitVersioning.3.9.50\build\Nerdbank.GitVersioning.props')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Nerdbank.GitVersioning.3.9.50\build\Nerdbank.GitVersioning.props'))" />
     <Error Condition="!Exists('packages\Nerdbank.GitVersioning.3.9.50\build\Nerdbank.GitVersioning.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Nerdbank.GitVersioning.3.9.50\build\Nerdbank.GitVersioning.targets'))" />
+    <Error Condition="!Exists('packages\StyleCop.MSBuild.6.2.0\build\StyleCop.MSBuild.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\StyleCop.MSBuild.6.2.0\build\StyleCop.MSBuild.targets'))" />
   </Target>
   <Import Project="packages\Nerdbank.GitVersioning.3.9.50\build\Nerdbank.GitVersioning.targets" Condition="Exists('packages\Nerdbank.GitVersioning.3.9.50\build\Nerdbank.GitVersioning.targets')" />
   <Import Project="packages\StyleCop.MSBuild.6.2.0\build\StyleCop.MSBuild.targets" Condition="Exists('packages\StyleCop.MSBuild.6.2.0\build\StyleCop.MSBuild.targets')" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('packages\StyleCop.MSBuild.6.2.0\build\StyleCop.MSBuild.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\StyleCop.MSBuild.6.2.0\build\StyleCop.MSBuild.targets'))" />
-  </Target>
 </Project>

--- a/devices/Paj7620/Paj7620.nfproj
+++ b/devices/Paj7620/Paj7620.nfproj
@@ -44,6 +44,7 @@
   <ItemGroup>
     <None Include="Paj7620.nuspec" />
     <None Include="packages.config" />
+    <Compile Include="Gesture.cs" />
     <Compile Include="Paj7620.cs" />
     <None Include="README.md" />
   </ItemGroup>

--- a/devices/Paj7620/Paj7620.nuspec
+++ b/devices/Paj7620/Paj7620.nuspec
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
+  <metadata>
+    <id>nanoFramework.Iot.Device.Paj7620</id>
+    <version>$version$</version>
+    <title>nanoFramework.Iot.Device.Paj7620</title>
+    <authors>nanoframework</authors>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <license type="file">LICENSE.md</license>
+    <releaseNotes>
+    </releaseNotes>
+    <readme>docs\README.md</readme>
+    <developmentDependency>false</developmentDependency>
+    <projectUrl>https://github.com/nanoframework/nanoFramework.IoT.Device</projectUrl>
+    <icon>images\nf-logo.png</icon>
+    <repository type="git" url="https://github.com/nanoframework/nanoFramework.IoT.Device" commit="$commit$" />
+    <copyright>Copyright (c) .NET Foundation and Contributors</copyright>
+    <description>This package includes the PAJ7620U2 gesture sensor binding Iot.Device.Paj7620 for .NET nanoFramework C# projects.</description>
+    <summary>PAJ7620U2 gesture sensor binding for .NET nanoFramework C# projects</summary>
+    <tags>nanoFramework C# csharp netmf netnf Iot.Device.Paj7620 paj7620 gesture sensor</tags>
+    <dependencies>
+      <dependency id="nanoFramework.CoreLibrary" version="1.17.11" />
+      <dependency id="nanoFramework.System.Device.I2c" version="1.1.29" />
+      <dependency id="nanoFramework.System.Device.Model" version="1.2.862" />
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="bin\Release\Iot.Device.Paj7620.dll" target="lib\Iot.Device.Paj7620.dll" />
+    <file src="bin\Release\Iot.Device.Paj7620.pdb" target="lib\Iot.Device.Paj7620.pdb" />
+    <file src="bin\Release\Iot.Device.Paj7620.pdbx" target="lib\Iot.Device.Paj7620.pdbx" />
+    <file src="bin\Release\Iot.Device.Paj7620.pe" target="lib\Iot.Device.Paj7620.pe" />
+    <file src="bin\Release\Iot.Device.Paj7620.xml" target="lib\Iot.Device.Paj7620.xml" />
+    <file src="README.md" target="docs\" />
+    <file src="..\..\assets\nf-logo.png" target="images" />
+    <file src="..\..\LICENSE.md" target="" />
+  </files>
+</package>

--- a/devices/Paj7620/Paj7620.sln
+++ b/devices/Paj7620/Paj7620.sln
@@ -1,0 +1,34 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30413.136
+MinimumVisualStudioVersion = 15.0.26124.0
+Project("{11A8DD76-328B-46DF-9F39-F559912D0360}") = "Paj7620", "Paj7620.nfproj", "{E79903D4-4F7C-4FB5-8078-086CD3B3252B}"
+EndProject
+Project("{11A8DD76-328B-46DF-9F39-F559912D0360}") = "Paj7620.Samples", "samples\Paj7620.Samples.nfproj", "{7EC388BC-55BB-4506-B93B-AD931F3F6D80}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{E79903D4-4F7C-4FB5-8078-086CD3B3252B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E79903D4-4F7C-4FB5-8078-086CD3B3252B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E79903D4-4F7C-4FB5-8078-086CD3B3252B}.Debug|Any CPU.Deploy.0 = Debug|Any CPU
+		{E79903D4-4F7C-4FB5-8078-086CD3B3252B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E79903D4-4F7C-4FB5-8078-086CD3B3252B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E79903D4-4F7C-4FB5-8078-086CD3B3252B}.Release|Any CPU.Deploy.0 = Release|Any CPU
+		{7EC388BC-55BB-4506-B93B-AD931F3F6D80}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7EC388BC-55BB-4506-B93B-AD931F3F6D80}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7EC388BC-55BB-4506-B93B-AD931F3F6D80}.Debug|Any CPU.Deploy.0 = Debug|Any CPU
+		{7EC388BC-55BB-4506-B93B-AD931F3F6D80}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7EC388BC-55BB-4506-B93B-AD931F3F6D80}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7EC388BC-55BB-4506-B93B-AD931F3F6D80}.Release|Any CPU.Deploy.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {72C71679-C4C6-4C43-A0F7-39094FCF9CF4}
+	EndGlobalSection
+EndGlobal

--- a/devices/Paj7620/Properties/AssemblyInfo.cs
+++ b/devices/Paj7620/Properties/AssemblyInfo.cs
@@ -1,0 +1,13 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("Iot.Device.Paj7620")]
+[assembly: AssemblyCompany("nanoFramework Contributors")]
+[assembly: AssemblyCopyright("Copyright(c).NET Foundation and Contributors")]
+
+[assembly: ComVisible(false)]
+

--- a/devices/Paj7620/Properties/AssemblyInfo.cs
+++ b/devices/Paj7620/Properties/AssemblyInfo.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 [assembly: AssemblyTitle("Iot.Device.Paj7620")]
@@ -10,4 +9,3 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCopyright("Copyright(c).NET Foundation and Contributors")]
 
 [assembly: ComVisible(false)]
-

--- a/devices/Paj7620/README.md
+++ b/devices/Paj7620/README.md
@@ -1,0 +1,73 @@
+﻿# PAJ7620U2 gesture sensor
+
+`Iot.Device.Paj7620` is a .NET nanoFramework binding for the PixArt PAJ7620U2 gesture sensor.
+
+## Features
+
+- I2C communication (`0x73` default address)
+- Device ID validation during initialization
+- Seeed-compatible initialization sequence
+- Gesture decoding for:
+  - Up, Down, Left, Right
+  - Forward, Backward
+  - Clockwise, CounterClockwise
+  - Wave
+
+## Usage
+
+Create `Paj7620`, call `Initialize()`, then poll `TryReadGesture(...)`.
+
+```csharp
+using Iot.Device.Paj7620;
+using System.Device.I2c;
+using System.Diagnostics;
+using System.Threading;
+using nanoFramework.Hardware.Esp32;
+
+Configuration.SetPinFunction(Gpio.IO05, DeviceFunction.I2C1_DATA);
+Configuration.SetPinFunction(Gpio.IO06, DeviceFunction.I2C1_CLOCK);
+
+I2cConnectionSettings settings = new(1, Paj7620.DefaultI2CAddress);
+
+using (Paj7620 sensor = new(I2cDevice.Create(settings)))
+{
+    sensor.GestureDebounceMilliseconds = 500;
+
+    sensor.Initialize();
+    Debug.WriteLine("PAJ7620 initialized.");
+
+    while (true)
+    {
+        if (sensor.TryReadGesture(out Gesture gesture))
+        {
+            Debug.WriteLine($"Gesture: {gesture}");
+        }
+
+        Thread.Sleep(50);
+    }
+}
+```
+
+See [samples](samples) for a complete sample application.
+
+## Gesture mapping
+
+The driver maps gesture result bitfields to the enum `Gesture` as follows:
+
+- `0x0001` -> `Up`
+- `0x0002` -> `Down`
+- `0x0004` -> `Left`
+- `0x0008` -> `Right`
+- `0x0010` -> `Forward`
+- `0x0020` -> `Backward`
+- `0x0040` -> `Clockwise`
+- `0x0080` -> `CounterClockwise`
+- `0x0100` -> `Wave`
+
+## Notes
+
+- The sensor requires successful `Initialize()` before reads.
+- There is a default 500 ms debounce period after each detected gesture. This can be adjusted at runtime using `sensor.GestureDebounceMilliseconds`.
+- Polling intervals between 20 ms and 100 ms are commonly stable in practice.
+- Reliable detection depends on distance, hand speed, and ambient conditions.
+- The sample uses I2C pins 5 (SDA) and 6 (SCL) on ESP32. Adjust pin configuration as needed for your board and wiring.

--- a/devices/Paj7620/Settings.StyleCop
+++ b/devices/Paj7620/Settings.StyleCop
@@ -1,0 +1,112 @@
+<StyleCopSettings Version="105">
+  <Analyzers>
+    <Analyzer AnalyzerId="StyleCop.CSharp.DocumentationRules">
+      <Rules>
+        <Rule Name="FileHeaderMustContainFileName">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+        <Rule Name="FileHeaderMustHaveValidCompanyText">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+        <Rule Name="FileHeaderFileNameDocumentationMustMatchTypeName">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+        <Rule Name="PropertyDocumentationMustHaveValueText">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">True</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+        <Rule Name="DocumentationTextMustBeginWithACapitalLetter">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">True</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+        <Rule Name="DocumentationTextMustEndWithAPeriod">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">True</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+        <Rule Name="FileHeaderMustShowCopyright">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+        <Rule Name="FileHeaderMustHaveCopyrightText">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+        <Rule Name="ElementDocumentationMustBeSpelledCorrectly">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+        <Rule Name="DocumentationTextMustContainWhitespace">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+      </Rules>
+      <AnalyzerSettings>
+        <BooleanProperty Name="IgnorePrivates">True</BooleanProperty>
+        <BooleanProperty Name="IgnoreInternals">True</BooleanProperty>
+      </AnalyzerSettings>
+    </Analyzer>
+    <Analyzer AnalyzerId="StyleCop.CSharp.ReadabilityRules">
+      <Rules>
+        <Rule Name="PrefixLocalCallsWithThis">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+        <Rule Name="PrefixCallsCorrectly">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+      </Rules>
+      <AnalyzerSettings />
+    </Analyzer>
+    <Analyzer AnalyzerId="StyleCop.CSharp.OrderingRules">
+      <Rules>
+        <Rule Name="UsingDirectivesMustBePlacedWithinNamespace">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+        <Rule Name="ElementsMustAppearInTheCorrectOrder">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+        <Rule Name="ElementsMustBeOrderedByAccess">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+      </Rules>
+      <AnalyzerSettings />
+    </Analyzer>
+    <Analyzer AnalyzerId="StyleCop.CSharp.NamingRules">
+      <Rules>
+        <Rule Name="FieldNamesMustNotBeginWithUnderscore">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+        <Rule Name="FieldNamesMustNotUseHungarianNotation">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+      </Rules>
+      <AnalyzerSettings />
+    </Analyzer>
+  </Analyzers>
+</StyleCopSettings>

--- a/devices/Paj7620/category.txt
+++ b/devices/Paj7620/category.txt
@@ -1,0 +1,3 @@
+gesture
+proximity
+human-interface

--- a/devices/Paj7620/category.txt
+++ b/devices/Paj7620/category.txt
@@ -1,3 +1,4 @@
-gesture
+motion
 proximity
-human-interface
+infrared
+i2c

--- a/devices/Paj7620/packages.config
+++ b/devices/Paj7620/packages.config
@@ -4,4 +4,5 @@
   <package id="nanoFramework.System.Device.I2c" version="1.1.29" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Device.Model" version="1.2.862" targetFramework="netnano1.0" />
   <package id="Nerdbank.GitVersioning" version="3.9.50" targetFramework="netnano1.0" developmentDependency="true" />
+  <package id="StyleCop.MSBuild" version="6.2.0" targetFramework="netnano1.0" developmentDependency="true" />
 </packages>

--- a/devices/Paj7620/packages.config
+++ b/devices/Paj7620/packages.config
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="nanoFramework.CoreLibrary" version="1.17.11" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Device.I2c" version="1.1.29" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Device.Model" version="1.2.862" targetFramework="netnano1.0" />
+  <package id="Nerdbank.GitVersioning" version="3.9.50" targetFramework="netnano1.0" developmentDependency="true" />
+</packages>

--- a/devices/Paj7620/packages.lock.json
+++ b/devices/Paj7620/packages.lock.json
@@ -1,0 +1,31 @@
+{
+  "version": 1,
+  "dependencies": {
+    ".NETnanoFramework,Version=v1.0": {
+      "nanoFramework.CoreLibrary": {
+        "type": "Direct",
+        "requested": "[1.17.11, 1.17.11]",
+        "resolved": "1.17.11",
+        "contentHash": "HezzAc0o2XrSGf85xSeD/6xsO6ohF9hX6/iMQ1IZS6Zw6umr4WfAN2Jv0BrPxkaYwzEegJxxZujkHoUIAqtOMw=="
+      },
+      "nanoFramework.System.Device.I2c": {
+        "type": "Direct",
+        "requested": "[1.1.29, 1.1.29]",
+        "resolved": "1.1.29",
+        "contentHash": "q8duNVWeK3RCiTmTZiO1UWr7s9HMsLnKWm5utxy9OQWeQtlh00l5CoFKxjot42s1NY5zLmfq7p7oWM/fgNEtlA=="
+      },
+      "nanoFramework.System.Device.Model": {
+        "type": "Direct",
+        "requested": "[1.2.862, 1.2.862]",
+        "resolved": "1.2.862",
+        "contentHash": "dARhyb8BHkje2P+7VphJpRLynVhMkC0U4pFNecLs6jw8DHRMMJyszcbgo/N0ALeYjilNk9hea+wzBLFrgZpsUQ=="
+      },
+      "Nerdbank.GitVersioning": {
+        "type": "Direct",
+        "requested": "[3.9.50, 3.9.50]",
+        "resolved": "3.9.50",
+        "contentHash": "HtOgGF6jZ+WYbXnCUCYPT8Y2d6mIJo9ozjK/FINTRsXdm4Zgv9GehUMa7EFoGQkqrMcDJNOIDwCmENnvXg4UbA=="
+      }
+    }
+  }
+}

--- a/devices/Paj7620/packages.lock.json
+++ b/devices/Paj7620/packages.lock.json
@@ -25,6 +25,12 @@
         "requested": "[3.9.50, 3.9.50]",
         "resolved": "3.9.50",
         "contentHash": "HtOgGF6jZ+WYbXnCUCYPT8Y2d6mIJo9ozjK/FINTRsXdm4Zgv9GehUMa7EFoGQkqrMcDJNOIDwCmENnvXg4UbA=="
+      },
+      "StyleCop.MSBuild": {
+        "type": "Direct",
+        "requested": "[6.2.0, 6.2.0]",
+        "resolved": "6.2.0",
+        "contentHash": "6J51Kt5X+Os+Ckp20SFP1SlLu3tZl+3qBhCMtJUJqGDgwSr4oHT+eg545hXCdp07tRB/8nZfXTOBDdA1XXvjUw=="
       }
     }
   }

--- a/devices/Paj7620/samples/Paj7620.Samples.nfproj
+++ b/devices/Paj7620/samples/Paj7620.Samples.nfproj
@@ -20,29 +20,31 @@
   </PropertyGroup>
   <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.props" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.props')" />
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.17.11.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.17.11\lib\mscorlib.dll</HintPath>
-    </Reference>
-    <Reference Include="nanoFramework.Hardware.Esp32, Version=1.6.37.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.Hardware.Esp32.1.6.37\lib\nanoFramework.Hardware.Esp32.dll</HintPath>
-    </Reference>
-    <Reference Include="nanoFramework.Runtime.Events, Version=1.11.32.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.Runtime.Events.1.11.32\lib\nanoFramework.Runtime.Events.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Device.I2c, Version=1.1.29.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.System.Device.I2c.1.1.29\lib\System.Device.I2c.dll</HintPath>
-    </Reference>
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
-    <!-- INSERT FILE REFERENCES HERE -->
-  </ItemGroup>
-  <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Program.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Paj7620.nfproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="mscorlib">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.17.11\lib\mscorlib.dll</HintPath>
+    </Reference>
+    <Reference Include="nanoFramework.Hardware.Esp32">
+      <HintPath>..\packages\nanoFramework.Hardware.Esp32.1.6.37\lib\nanoFramework.Hardware.Esp32.dll</HintPath>
+    </Reference>
+    <Reference Include="nanoFramework.Runtime.Events">
+      <HintPath>..\packages\nanoFramework.Runtime.Events.1.11.32\lib\nanoFramework.Runtime.Events.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Device.I2c">
+      <HintPath>..\packages\nanoFramework.System.Device.I2c.1.1.29\lib\System.Device.I2c.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="packages.lock.json" />
   </ItemGroup>
   <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.CSharp.targets" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.CSharp.targets')" />
   <ProjectExtensions>

--- a/devices/Paj7620/samples/Paj7620.Samples.nfproj
+++ b/devices/Paj7620/samples/Paj7620.Samples.nfproj
@@ -52,5 +52,5 @@
       <ProjectConfigurationsDeclaredAsItems />
     </ProjectCapabilities>
   </ProjectExtensions>
-  <!-- INSERT NBGV IMPORT HERE -->
+</Project>
 </Project>

--- a/devices/Paj7620/samples/Paj7620.Samples.nfproj
+++ b/devices/Paj7620/samples/Paj7620.Samples.nfproj
@@ -53,4 +53,3 @@
     </ProjectCapabilities>
   </ProjectExtensions>
 </Project>
-</Project>

--- a/devices/Paj7620/samples/Paj7620.Samples.nfproj
+++ b/devices/Paj7620/samples/Paj7620.Samples.nfproj
@@ -1,0 +1,54 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="Current" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Label="Globals">
+    <NanoFrameworkProjectSystemPath>$(MSBuildExtensionsPath)\nanoFramework\v1.0\</NanoFrameworkProjectSystemPath>
+  </PropertyGroup>
+  <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.Default.props" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.Default.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectTypeGuids>{11A8DD76-328B-46DF-9F39-F559912D0360};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ProjectGuid>{7EC388BC-55BB-4506-B93B-AD931F3F6D80}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <RootNamespace>Iot.Device.Paj7620.Samples</RootNamespace>
+    <AssemblyName>Iot.Device.Paj7620.Samples</AssemblyName>
+    <TargetFrameworkVersion>v1.0</TargetFrameworkVersion>
+    <DocumentationFile>bin\$(Configuration)\Iot.Device.Paj7620.Samples.xml</DocumentationFile>
+    <LangVersion>9.0</LangVersion>
+  </PropertyGroup>
+  <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.props" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.props')" />
+  <ItemGroup>
+    <Reference Include="mscorlib, Version=1.17.11.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.17.11\lib\mscorlib.dll</HintPath>
+    </Reference>
+    <Reference Include="nanoFramework.Hardware.Esp32, Version=1.6.37.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.Hardware.Esp32.1.6.37\lib\nanoFramework.Hardware.Esp32.dll</HintPath>
+    </Reference>
+    <Reference Include="nanoFramework.Runtime.Events, Version=1.11.32.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.Runtime.Events.1.11.32\lib\nanoFramework.Runtime.Events.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Device.I2c, Version=1.1.29.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.System.Device.I2c.1.1.29\lib\System.Device.I2c.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+    <!-- INSERT FILE REFERENCES HERE -->
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Program.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Paj7620.nfproj" />
+  </ItemGroup>
+  <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.CSharp.targets" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.CSharp.targets')" />
+  <ProjectExtensions>
+    <ProjectCapabilities>
+      <ProjectConfigurationsDeclaredAsItems />
+    </ProjectCapabilities>
+  </ProjectExtensions>
+  <!-- INSERT NBGV IMPORT HERE -->
+</Project>

--- a/devices/Paj7620/samples/Program.cs
+++ b/devices/Paj7620/samples/Program.cs
@@ -1,0 +1,75 @@
+//
+// Copyright (c) 2017 The nanoFramework project contributors
+// See LICENSE file in the project root for full license information.
+//
+
+using nanoFramework.Hardware.Esp32;
+using System.Device.I2c;
+using System.Diagnostics;
+using System.Threading;
+
+namespace Iot.Device.Paj7620.Samples
+{
+    /// <summary>
+    /// PAJ7620 sample entry point.
+    /// </summary>
+    public class Program
+    {
+        /// <summary>
+        /// Starts the sample loop and prints detected gestures.
+        /// </summary>
+        public static void Main()
+        {
+            // Configure I2C pins for your board before creating the device.
+            Configuration.SetPinFunction(Gpio.IO05, DeviceFunction.I2C1_DATA);
+            Configuration.SetPinFunction(Gpio.IO06, DeviceFunction.I2C1_CLOCK);
+
+            I2cConnectionSettings settings = new(1, Paj7620.DefaultI2CAddress);
+
+            using (Paj7620 sensor = new(I2cDevice.Create(settings)))
+            {
+                sensor.GestureDebounceMilliseconds = 500;
+
+                sensor.Initialize();
+                Debug.WriteLine("PAJ7620 initialized.");
+
+                for (int i = 0; i < int.MaxValue; i++)
+                {
+                    if (sensor.TryReadGesture(out Gesture gesture))
+                    {
+                        Debug.WriteLine($"Gesture: {GetGestureName(gesture)}");
+                    }
+
+                    Thread.Sleep(100);
+                }
+            }
+        }
+
+        private static string GetGestureName(Gesture gesture)
+        {
+            switch (gesture)
+            {
+                case Gesture.Up:
+                    return "Up";
+                case Gesture.Down:
+                    return "Down";
+                case Gesture.Left:
+                    return "Left";
+                case Gesture.Right:
+                    return "Right";
+                case Gesture.Forward:
+                    return "Forward";
+                case Gesture.Backward:
+                    return "Backward";
+                case Gesture.Clockwise:
+                    return "Clockwise";
+                case Gesture.CounterClockwise:
+                    return "CounterClockwise";
+                case Gesture.Wave:
+                    return "Wave";
+                default:
+                    return "None";
+            }
+        }
+    }
+}

--- a/devices/Paj7620/samples/Properties/AssemblyInfo.cs
+++ b/devices/Paj7620/samples/Properties/AssemblyInfo.cs
@@ -1,0 +1,13 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("Iot.Device.Paj7620.Samples")]
+[assembly: AssemblyCompany("nanoFramework Contributors")]
+[assembly: AssemblyCopyright("Copyright(c).NET Foundation and Contributors")]
+
+[assembly: ComVisible(false)]
+

--- a/devices/Paj7620/samples/packages.config
+++ b/devices/Paj7620/samples/packages.config
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="nanoFramework.CoreLibrary" version="1.17.11" targetFramework="netnano1.0" />
+  <package id="nanoFramework.Hardware.Esp32" version="1.6.37" targetFramework="netnano1.0" />
+  <package id="nanoFramework.Runtime.Events" version="1.11.32" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Device.I2c" version="1.1.29" targetFramework="netnano1.0" />
+</packages>

--- a/devices/Paj7620/samples/packages.lock.json
+++ b/devices/Paj7620/samples/packages.lock.json
@@ -1,0 +1,31 @@
+{
+  "version": 1,
+  "dependencies": {
+    ".NETnanoFramework,Version=v1.0": {
+      "nanoFramework.CoreLibrary": {
+        "type": "Direct",
+        "requested": "[1.17.11, 1.17.11]",
+        "resolved": "1.17.11",
+        "contentHash": "HezzAc0o2XrSGf85xSeD/6xsO6ohF9hX6/iMQ1IZS6Zw6umr4WfAN2Jv0BrPxkaYwzEegJxxZujkHoUIAqtOMw=="
+      },
+      "nanoFramework.Hardware.Esp32": {
+        "type": "Direct",
+        "requested": "[1.6.37, 1.6.37]",
+        "resolved": "1.6.37",
+        "contentHash": "vQ9wy4esiBGaxveLPIxwAoBXj3vB0BotHYdTJtFIfgdpkEjsD2synrcD8xTv3kCNoCdptcDO0eSabkqu5eGIAQ=="
+      },
+      "nanoFramework.Runtime.Events": {
+        "type": "Direct",
+        "requested": "[1.11.32, 1.11.32]",
+        "resolved": "1.11.32",
+        "contentHash": "NyLUIwJDlpl5VKSd+ljmdDtO2WHHBvPvruo1ccaL+hd79z+6XMYze1AccOVXKGiZenLBCwDmFHwpgIQyHkM7GA=="
+      },
+      "nanoFramework.System.Device.I2c": {
+        "type": "Direct",
+        "requested": "[1.1.29, 1.1.29]",
+        "resolved": "1.1.29",
+        "contentHash": "q8duNVWeK3RCiTmTZiO1UWr7s9HMsLnKWm5utxy9OQWeQtlh00l5CoFKxjot42s1NY5zLmfq7p7oWM/fgNEtlA=="
+      }
+    }
+  }
+}

--- a/devices/Paj7620/version.json
+++ b/devices/Paj7620/version.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
+  "version": "1.2",
+  "semVer1NumericIdentifierPadding": 3,
+  "nuGetPackageVersion": {
+    "semVer": 2.0
+  },
+  "publicReleaseRefSpec": [
+    "^refs/heads/develop$",
+    "^refs/heads/main$",
+    "^refs/heads/v\\d+(?:\\.\\d+)?$"
+  ],
+  "cloudBuild": {
+    "setAllVariables": true
+  }
+}

--- a/devices/Paj7620/version.json
+++ b/devices/Paj7620/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.2",
+  "version": "1.0",
   "semVer1NumericIdentifierPadding": 3,
   "nuGetPackageVersion": {
     "semVer": 2.0


### PR DESCRIPTION
Add new Iot.Device.Paj7620 device with initialization and part ID validation.

Implement gesture decoding and runtime-configurable debounce handling.


<!--- In the TITLE (↑↑↑↑ above ↑↑↑↑ **NOT HERE**) provide a general, short summary of your changes -->
<!--- Please DO NOT use references to other PR's or issues -->

## Description
<!--- Describe your changes in detail -->
- This PR adds a new Paj7620 binding for the PixArt PAJ7620U2 gesture sensor.
- The driver initializes the sensor using a Seeed-compatible register sequence and validates the device part ID before use.
- The implementation decodes gesture registers into Gesture values (Up, Down, Left, Right, Forward, Backward, Clockwise, CounterClockwise, Wave).
- The gesture debounce window is runtime-configurable through GestureDebounceMilliseconds.
- A sample app was added under devices/Paj7620/samples showing board pin setup, initialization, and gesture polling.
- Packaging metadata was added, including Paj7620.nuspec, version.json, and category.txt.
- Device documentation was added in README.md.
<!--- Bulleted list. Full sentences. Ending with a dot. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If this **fixes** OR **closes** OR  **resolves** an open issue, please link to the issue there using the template bellow (mind the pattern to link there as all issues are tracked in the Home repository) -->
<!--- **JUST** replace NNNNN with the issue number -->

- This change adds native nanoFramework support for the PAJ7620U2 gesture sensor, which was missing.
- It provides a reusable device binding and ready-to-use sample for embedded applications needing gesture input.
- It improves reliability by validating device identity and by allowing debounce configuration for real-world hand movement behavior.
## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- The device project and sample project were built locally in Visual Studio.
- The sample was deployed to an ESP32 target and validated against connected PAJ7620U2 hardware.
- Sensor initialization and part ID check were verified.
- Gesture polling was verified in runtime, including configurable debounce behavior.
- Used device: https://www.seeedstudio.com/Grove-Gesture-PAJ7620U2.html
## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [x] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [ ] My code follows the code style of this project (only if there are changes in source code).
- [x] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [x] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.