### PR TITLE
[MulticastDns] Fix mDNS response encoding per RFC 6762

### DIFF
--- a/devices/MulticastDns/Entities/ARecord.cs
+++ b/devices/MulticastDns/Entities/ARecord.cs
@@ -21,7 +21,7 @@ namespace Iot.Device.MulticastDns.Entities
         public ARecord(string domain, IPAddress address, int ttl = 2000) : base(domain, DnsResourceType.A, ttl)
             => Address = address;
 
-        internal ARecord(PacketParser packet, string domain, int ttl, int length) : base(domain, DnsResourceType.A, ttl)
+        internal ARecord(PacketParser packet, string domain, int ttl, int length, ushort rrClass) : base(domain, DnsResourceType.A, ttl, rrClass)
             => Address = new IPAddress(packet.ReadBytes(length));
     }
 }

--- a/devices/MulticastDns/Entities/AaaaRecord.cs
+++ b/devices/MulticastDns/Entities/AaaaRecord.cs
@@ -21,7 +21,7 @@ namespace Iot.Device.MulticastDns.Entities
         public AaaaRecord(string domain, IPAddress address, int ttl = 2000) : base(domain, DnsResourceType.AAAA, ttl)
             => Address = address;
 
-        internal AaaaRecord(PacketParser packet, string domain, int ttl, int length) : base(domain, DnsResourceType.AAAA, ttl)
+        internal AaaaRecord(PacketParser packet, string domain, int ttl, int length, ushort rrClass) : base(domain, DnsResourceType.AAAA, ttl, rrClass)
             => Address = new IPAddress(packet.ReadBytes(length));
     }
 }

--- a/devices/MulticastDns/Entities/AddressResource.cs
+++ b/devices/MulticastDns/Entities/AddressResource.cs
@@ -17,7 +17,8 @@ namespace Iot.Device.MulticastDns.Entities
         /// <param name="domain">The domain this Record points to.</param>
         /// <param name="type">The type of this resource.</param>
         /// <param name="ttl">The TTL of this resource.</param>
-        public AddressResource(string domain, DnsResourceType type, int ttl) : base(domain, type, ttl)
+        /// <param name="resourceClass">The DNS class of this resource.</param>
+        protected AddressResource(string domain, DnsResourceType type, int ttl, ushort resourceClass = ClassInternetCacheFlush) : base(domain, type, ttl, resourceClass)
         {
         }
 

--- a/devices/MulticastDns/Entities/AnyRecord.cs
+++ b/devices/MulticastDns/Entities/AnyRecord.cs
@@ -14,7 +14,7 @@ namespace Iot.Device.MulticastDns.Entities
     /// </summary>
     public class AnyRecord : Resource
     {
-        internal AnyRecord(PacketParser packet, string domain, int ttl, int length) : base(domain, DnsResourceType.ANY, ttl)
+        internal AnyRecord(PacketParser packet, string domain, int ttl, int length, ushort rrClass) : base(domain, DnsResourceType.ANY, ttl, rrClass)
         {
             if (length < 0)
             {

--- a/devices/MulticastDns/Entities/CnameRecord.cs
+++ b/devices/MulticastDns/Entities/CnameRecord.cs
@@ -20,7 +20,7 @@ namespace Iot.Device.MulticastDns.Entities
         public CnameRecord(string domain, string targetDomain, int ttl = 2000) : base(domain, DnsResourceType.CNAME, ttl)
             => Target = targetDomain;
 
-        internal CnameRecord(PacketParser packet, string domain, int ttl) : base(domain, DnsResourceType.CNAME, ttl)
+        internal CnameRecord(PacketParser packet, string domain, int ttl, ushort rrClass) : base(domain, DnsResourceType.CNAME, ttl, rrClass)
             => Target = packet.ReadDomain();
     }
 }

--- a/devices/MulticastDns/Entities/Message.cs
+++ b/devices/MulticastDns/Entities/Message.cs
@@ -12,10 +12,8 @@ namespace Iot.Device.MulticastDns.Entities
     /// </summary>
     public class Message
     {
-        private static readonly System.Random _generator = new();
-
         private ushort _id;
-        private ushort _flags = 0;
+        private ushort _flags;
 
         /// <summary>
         /// The list of <see cref="Question">Questions</see> in the message.
@@ -47,7 +45,7 @@ namespace Iot.Device.MulticastDns.Entities
         /// <param name="flags">The header flags for this message.</param>
         public Message(DnsHeaderFlags flags)
         {
-            _id = (ushort)_generator.Next(1 << 16);
+            _id = 0; // mDNS MUST use ID=0 per RFC 6762 §18.1
             _flags = (ushort)flags;
         }
 

--- a/devices/MulticastDns/Entities/Message.cs
+++ b/devices/MulticastDns/Entities/Message.cs
@@ -159,22 +159,22 @@ namespace Iot.Device.MulticastDns.Entities
         {
             string domain = packet.ReadDomain();
             ushort rrType = packet.ReadUShort();
-            _ = packet.ReadUShort();
+            ushort rrClass = packet.ReadUShort();
             int ttl = packet.ReadInt();
             ushort length = packet.ReadUShort();
 
             switch (GetResourceType(rrType))
             {
-                case DnsResourceType.A: return new ARecord(packet, domain, ttl, length);
-                case DnsResourceType.CNAME: return new CnameRecord(packet, domain, ttl);
-                case DnsResourceType.PTR: return new PtrRecord(packet, domain, ttl);
-                case DnsResourceType.TXT: return new TxtRecord(packet, domain, ttl);
-                case DnsResourceType.AAAA: return new AaaaRecord(packet, domain, ttl, length);
-                case DnsResourceType.SRV: return new SrvRecord(packet, domain, ttl);
-                case DnsResourceType.ANY: return new AnyRecord(packet, domain, ttl, length);
+                case DnsResourceType.A: return new ARecord(packet, domain, ttl, length, rrClass);
+                case DnsResourceType.CNAME: return new CnameRecord(packet, domain, ttl, rrClass);
+                case DnsResourceType.PTR: return new PtrRecord(packet, domain, ttl, rrClass);
+                case DnsResourceType.TXT: return new TxtRecord(packet, domain, ttl, rrClass);
+                case DnsResourceType.AAAA: return new AaaaRecord(packet, domain, ttl, length, rrClass);
+                case DnsResourceType.SRV: return new SrvRecord(packet, domain, ttl, rrClass);
+                case DnsResourceType.ANY: return new AnyRecord(packet, domain, ttl, length, rrClass);
                 default:
                     packet.ReadBytes(length);
-                    return new Resource(domain, ttl);
+                    return new Resource(domain, ttl, rrClass);
             }
         }
 

--- a/devices/MulticastDns/Entities/PtrRecord.cs
+++ b/devices/MulticastDns/Entities/PtrRecord.cs
@@ -17,7 +17,7 @@ namespace Iot.Device.MulticastDns.Entities
         /// <param name="domain">The domain this Record is about.</param>
         /// <param name="targetDomain">The targetDomain which points to the domain.</param>
         /// <param name="ttl">The TTL of this resource.</param>
-        public PtrRecord(string domain, string targetDomain, int ttl = 2000) : base(domain, DnsResourceType.PTR, ttl)
+        public PtrRecord(string domain, string targetDomain, int ttl = 2000) : base(domain, DnsResourceType.PTR, ttl, ClassInternet)
             => Target = targetDomain;
 
         internal PtrRecord(PacketParser packet, string domain, int ttl, ushort rrClass) : base(domain, DnsResourceType.PTR, ttl, rrClass)

--- a/devices/MulticastDns/Entities/PtrRecord.cs
+++ b/devices/MulticastDns/Entities/PtrRecord.cs
@@ -20,7 +20,7 @@ namespace Iot.Device.MulticastDns.Entities
         public PtrRecord(string domain, string targetDomain, int ttl = 2000) : base(domain, DnsResourceType.PTR, ttl)
             => Target = targetDomain;
 
-        internal PtrRecord(PacketParser packet, string domain, int ttl) : base(domain, DnsResourceType.PTR, ttl)
+        internal PtrRecord(PacketParser packet, string domain, int ttl, ushort rrClass) : base(domain, DnsResourceType.PTR, ttl, rrClass)
             => Target = packet.ReadDomain();
     }
 }

--- a/devices/MulticastDns/Entities/Resource.cs
+++ b/devices/MulticastDns/Entities/Resource.cs
@@ -44,7 +44,7 @@ namespace Iot.Device.MulticastDns.Entities
         /// <summary>
         /// Gets The class of this resource.
         /// </summary>
-        public ushort ResourceClass { get; } = 1; // IN
+        public ushort ResourceClass { get; } = 0x8001; // IN + cache-flush (RFC 6762 §11.3)
 
         /// <summary>
         /// Gets or sets The TTL of this resource.

--- a/devices/MulticastDns/Entities/Resource.cs
+++ b/devices/MulticastDns/Entities/Resource.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Iot.Device.MulticastDns.Enum;
@@ -12,12 +12,23 @@ namespace Iot.Device.MulticastDns.Entities
     public class Resource
     {
         /// <summary>
+        /// Internet class with the cache-flush bit set (RFC 6762 §11.3). Default for outgoing mDNS records.
+        /// </summary>
+        public const ushort ClassInternetCacheFlush = 0x8001;
+
+        /// <summary>
+        /// Internet class (IN). Standard DNS class for internet records.
+        /// </summary>
+        public const ushort ClassInternet = 0x0001;
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="Resource" /> class.
         /// </summary>
         /// <param name="domain">The domain this resource is about.</param>
         /// <param name="type">The type of this resource.</param>
         /// <param name="ttl">The TTL of this resource.</param>
-        public Resource(string domain, DnsResourceType type, int ttl) : this(domain, ttl)
+        /// <param name="resourceClass">The DNS class of this resource.</param>
+        public Resource(string domain, DnsResourceType type, int ttl, ushort resourceClass = ClassInternetCacheFlush) : this(domain, ttl, resourceClass)
             => ResourceType = type;
 
         /// <summary>
@@ -25,10 +36,12 @@ namespace Iot.Device.MulticastDns.Entities
         /// </summary>
         /// <param name="domain">The domain this resource is about.</param>
         /// <param name="ttl">The TTL of this resource.</param>
-        public Resource(string domain, int ttl)
+        /// <param name="resourceClass">The DNS class of this resource.</param>
+        public Resource(string domain, int ttl, ushort resourceClass = ClassInternetCacheFlush)
         {
             Domain = domain;
             Ttl = ttl;
+            ResourceClass = resourceClass;
         }
 
         /// <summary>
@@ -44,7 +57,7 @@ namespace Iot.Device.MulticastDns.Entities
         /// <summary>
         /// Gets The class of this resource.
         /// </summary>
-        public ushort ResourceClass { get; } = 0x8001; // IN + cache-flush (RFC 6762 §11.3)
+        public ushort ResourceClass { get; }
 
         /// <summary>
         /// Gets or sets The TTL of this resource.
@@ -75,6 +88,6 @@ namespace Iot.Device.MulticastDns.Entities
         /// Returns a byte[] representation of this Resource.
         /// </summary>
         /// <returns>A byte[] representation of this Resource.</returns>
-        protected virtual byte[] GetBytesInternal() => new byte[0]; 
+        protected virtual byte[] GetBytesInternal() => new byte[0];
     }
 }

--- a/devices/MulticastDns/Entities/Response.cs
+++ b/devices/MulticastDns/Entities/Response.cs
@@ -14,7 +14,7 @@ namespace Iot.Device.MulticastDns.Entities
         /// <summary>
         /// Initializes a new instance of the <see cref="Response" /> class.
         /// </summary>
-        public Response() : base(DnsHeaderFlags.Response)
+        public Response() : base(DnsHeaderFlags.Response | DnsHeaderFlags.AuthoritativeAnswer)
         {
         }
 

--- a/devices/MulticastDns/Entities/SrvRecord.cs
+++ b/devices/MulticastDns/Entities/SrvRecord.cs
@@ -28,7 +28,7 @@ namespace Iot.Device.MulticastDns.Entities
             Target = targetDomain;
         }
 
-        internal SrvRecord(PacketParser packet, string domain, int ttl) : base(domain, DnsResourceType.SRV, ttl)
+        internal SrvRecord(PacketParser packet, string domain, int ttl, ushort rrClass) : base(domain, DnsResourceType.SRV, ttl, rrClass)
         {
             Priority = packet.ReadUShort();
             Weight = packet.ReadUShort();

--- a/devices/MulticastDns/Entities/TargetResource.cs
+++ b/devices/MulticastDns/Entities/TargetResource.cs
@@ -17,7 +17,7 @@ namespace Iot.Device.MulticastDns.Entities
         /// <param name="domain">The domain this Record points to.</param>
         /// <param name="type">The type of this resource.</param>
         /// <param name="ttl">The TTL of this resource.</param>
-        public TargetResource(string domain, DnsResourceType type, int ttl) : base(domain, type, ttl)
+        protected TargetResource(string domain, DnsResourceType type, int ttl, ushort resourceClass = ClassInternetCacheFlush) : base(domain, type, ttl, resourceClass)
         {
         }
 

--- a/devices/MulticastDns/Entities/TxtRecord.cs
+++ b/devices/MulticastDns/Entities/TxtRecord.cs
@@ -20,7 +20,14 @@ namespace Iot.Device.MulticastDns.Entities
         /// <param name="txt">The text this resource represents.</param>
         /// <param name="ttl">The TTL of this SRVRecord.</param>
         public TxtRecord(string domain, string txt, int ttl = 2000) : base(domain, DnsResourceType.TXT, ttl)
-            => Txt = txt;
+        {
+            if (Encoding.UTF8.GetBytes(txt).Length > 255)
+            {
+                throw new ArgumentException($"TXT record value exceeds maximum encoded length of 255 bytes.", nameof(txt));
+            }
+
+            Txt = txt;
+        }
 
         internal TxtRecord(PacketParser packet, string domain, int ttl) : base(domain, DnsResourceType.TXT, ttl)
             => Txt = packet.ReadString();

--- a/devices/MulticastDns/Entities/TxtRecord.cs
+++ b/devices/MulticastDns/Entities/TxtRecord.cs
@@ -29,7 +29,7 @@ namespace Iot.Device.MulticastDns.Entities
             Txt = txt;
         }
 
-        internal TxtRecord(PacketParser packet, string domain, int ttl) : base(domain, DnsResourceType.TXT, ttl)
+        internal TxtRecord(PacketParser packet, string domain, int ttl, ushort rrClass) : base(domain, DnsResourceType.TXT, ttl, rrClass)
             => Txt = packet.ReadString();
 
         /// <summary>

--- a/devices/MulticastDns/Entities/TxtRecord.cs
+++ b/devices/MulticastDns/Entities/TxtRecord.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Text;
 using Iot.Device.MulticastDns.Enum;
 using Iot.Device.MulticastDns.Package;
@@ -33,6 +34,13 @@ namespace Iot.Device.MulticastDns.Entities
         /// Returns a byte[] representation of this Resource.
         /// </summary>
         /// <returns>A byte[] representation of this Resource.</returns>
-        protected override byte[] GetBytesInternal() => Encoding.UTF8.GetBytes(Txt);
+        protected override byte[] GetBytesInternal()
+        {
+            var txtBytes = Encoding.UTF8.GetBytes(Txt);
+            var result = new byte[1 + txtBytes.Length];
+            result[0] = (byte)txtBytes.Length;
+            Array.Copy(txtBytes, 0, result, 1, txtBytes.Length);
+            return result;
+        }
     }
 }

--- a/devices/MulticastDns/Enum/DnsHeaderFlags.cs
+++ b/devices/MulticastDns/Enum/DnsHeaderFlags.cs
@@ -27,8 +27,8 @@ namespace Iot.Device.MulticastDns.Enum
         Query = 0x0,
 
         /// <summary>
-        /// Indicates a successful response
+        /// Indicates a successful response (QR=1, AA=1 per RFC 6762)
         /// </summary>
-        Response = 0x8000
+        Response = 0x8400
     }
 }

--- a/devices/MulticastDns/Enum/DnsHeaderFlags.cs
+++ b/devices/MulticastDns/Enum/DnsHeaderFlags.cs
@@ -27,8 +27,13 @@ namespace Iot.Device.MulticastDns.Enum
         Query = 0x0,
 
         /// <summary>
-        /// Indicates a successful response (QR=1, AA=1 per RFC 6762)
+        /// Indicates a DNS response (QR=1).
         /// </summary>
-        Response = 0x8400
+        Response = 0x8000,
+
+        /// <summary>
+        /// Indicates an authoritative answer (AA=1).
+        /// </summary>
+        AuthoritativeAnswer = 0x0400
     }
 }


### PR DESCRIPTION
<!--- In the TITLE (↑↑↑↑ above ↑↑↑↑ **NOT HERE**) provide a general, short summary of your changes -->
<!--- Please DO NOT use references to other PR's or issues -->

## Description
Three correctness fixes for mDNS responses:

- DnsHeaderFlags.Response: set AA bit (0x8400 instead of 0x8000). RFC 6762 §18.4 requires the Authoritative Answer bit to be set in all mDNS responses. Without it, some clients (e.g. avahi) may treat responses as non-authoritative and behave unexpectedly.

- Resource.ResourceClass: set cache-flush bit (0x8001 instead of 0x0001). RFC 6762 §11.3 requires the cache-flush bit in the rrclass of every resource record in a response. Without it, clients treat the record as coming from a legacy unicast DNS server (10 s max TTL, lower trust), which can prevent successful service resolution.

- TxtRecord.GetBytesInternal: add DNS character-string length prefix. DNS TXT RDATA is one or more length-prefixed character-strings (RFC 1035 §3.3.14). The previous implementation wrote raw UTF-8 bytes with no length byte, producing malformed TXT records that mDNS clients could not parse correctly.

## Motivation and Context
Be RFC compliant

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
On device

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
