### PR TITLE
[AtModem] Fix `ArgumentOutOfRangeException` when header value is empty

### DIFF
--- a/devices/AtModem/Http/Http/WebHeaderCollection.cs
+++ b/devices/AtModem/Http/Http/WebHeaderCollection.cs
@@ -427,7 +427,16 @@ namespace System.Net
             }
 
             string name = header.Substring(0, colpos);
-            string value = header.Substring(colpos + 1);
+            // Fix: Check bounds before Substring to prevent ArgumentOutOfRangeException
+            string value;
+            if (colpos + 1 >= header.Length)
+            {
+                value = string.Empty;
+            }
+            else
+            {
+                value = header.Substring(colpos + 1);
+            }
 
             name = CheckBadChars(name, false);
             ThrowOnRestrictedHeader(name);


### PR DESCRIPTION
## Description
- Added bounds check before `Substring` call in `WebHeaderCollection.Add(string header)` method.
- Prevents `ArgumentOutOfRangeException` when header ends with ':' and has no value (e.g., `"Authorization:"`).

## Motivation and Context
- Currently, calling `Add(string header)` with a header string that has no value after the colon (e.g., `"Authorization:"`) causes a crash because `Substring(colpos + 1)` is called without checking bounds.
- This issue was discovered during development of an embedded Web API server (PicoServer.Nano) running on ESP32.
- In sync with nanoframework/System.Net.Http#488.

## How Has This Been Tested?
- Manually tested on ESP32 device running nanoFramework using `curl -H "Authorization:" http://<device-ip>/hello`.
- Verified that the exception no longer occurs and the request is handled gracefully.
- Unit tests added @ nanoframework/System.Net.Http#488.

## Screenshots

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My changes require an update to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed.
- [ ] I have added new tests to cover my changes.