### PR TITLE
[Dhcp Server] Fix DHCP lease tracking and race condition

### DIFF
--- a/devices/DhcpServer/DhcpServer.cs
+++ b/devices/DhcpServer/DhcpServer.cs
@@ -240,23 +240,17 @@ namespace Iot.Device.DhcpServer
                                     break;
                                 }
 
-                                byte[] yourIp;
+                                byte[] yourIp = null;
 
                                 // Do we have an option asking for a specific IP address?
                                 var reqIp = dhcpReq.RequestedIpAddress;
-                                if (reqIp != new IPAddress(0))
+                                if (reqIp != new IPAddress(0) && _dhcpIpList.Contains(reqIp))
                                 {
-                                    // We do have a request for an IP, maybe it was connected before
-                                    if (_dhcpIpList.Contains(reqIp))
-                                    {
-                                        yourIp = reqIp.GetAddressBytes();
-                                    }
-                                    else
-                                    {
-                                        yourIp = GetFirstAvailableIp();
-                                    }
+                                    // Client was connected before and still holds a valid lease
+                                    yourIp = reqIp.GetAddressBytes();
                                 }
-                                else
+
+                                if (yourIp == null)
                                 {
                                     yourIp = GetFirstAvailableIp();
                                 }
@@ -277,11 +271,22 @@ namespace Iot.Device.DhcpServer
                                     {
                                         Debug.WriteLine("Received REQUEST without ciaddr, client is INIT-REBOOT");
 
-                                        if (!_dhcpIpList.Contains(dhcpReq.RequestedIpAddress))
+                                        lock (_dhcpListLock)
                                         {
-                                            _dhcpIpList.Add(dhcpReq.RequestedIpAddress);
-                                            _dhcpHardwareAddressList.Add(dhcpReq.ClientHardwareAddressAsString);
-                                            _dhcpLastRequest.Add(DateTime.UtcNow);
+                                            int existingIdx = _dhcpIpList.IndexOf(dhcpReq.RequestedIpAddress);
+
+                                            if (existingIdx >= 0)
+                                            {
+                                                // Refresh the lease timestamp so the client's reboot does
+                                                // not cause the lease to expire prematurely
+                                                _dhcpLastRequest[existingIdx] = DateTime.UtcNow;
+                                            }
+                                            else
+                                            {
+                                                _dhcpIpList.Add(dhcpReq.RequestedIpAddress);
+                                                _dhcpHardwareAddressList.Add(dhcpReq.ClientHardwareAddressAsString);
+                                                _dhcpLastRequest.Add(DateTime.UtcNow);
+                                            }
                                         }
 
                                         _sender.Send(MessageBuilder.CreateAck(dhcpReq, _ipAddress, dhcpReq.RequestedIpAddress, _mask, _options).GetBytes());
@@ -334,6 +339,24 @@ namespace Iot.Device.DhcpServer
                                 else if (serverIdentifier.Equals(_ipAddress))
                                 {
                                     Debug.WriteLine("Received REQUEST with server identifier, client is SELECTING");
+
+                                    // Track the confirmed lease so INIT-REBOOT and RENEW can find it.
+                                    // This must be done here; DISCOVER only offers an IP without committing.
+                                    lock (_dhcpListLock)
+                                    {
+                                        int existingIdx = _dhcpIpList.IndexOf(dhcpReq.RequestedIpAddress);
+
+                                        if (existingIdx >= 0)
+                                        {
+                                            _dhcpLastRequest[existingIdx] = DateTime.UtcNow;
+                                        }
+                                        else
+                                        {
+                                            _dhcpIpList.Add(dhcpReq.RequestedIpAddress);
+                                            _dhcpHardwareAddressList.Add(dhcpReq.ClientHardwareAddressAsString);
+                                            _dhcpLastRequest.Add(DateTime.UtcNow);
+                                        }
+                                    }
 
                                     _sender.Send(MessageBuilder.CreateAck(dhcpReq, _ipAddress, dhcpReq.RequestedIpAddress, _mask, _options).GetBytes());
                                 }

--- a/devices/DhcpServer/DhcpServer.cs
+++ b/devices/DhcpServer/DhcpServer.cs
@@ -244,15 +244,23 @@ namespace Iot.Device.DhcpServer
 
                                 // Do we have an option asking for a specific IP address?
                                 var reqIp = dhcpReq.RequestedIpAddress;
-                                if (reqIp != new IPAddress(0) && _dhcpIpList.Contains(reqIp))
+                                lock (_dhcpListLock)
                                 {
-                                    // Client was connected before and still holds a valid lease
-                                    yourIp = reqIp.GetAddressBytes();
-                                }
+                                    if (reqIp != new IPAddress(0))
+                                    {
+                                        int existingIdx = FindLeaseIndex(reqIp);
+                                        if (existingIdx >= 0 && (string)_dhcpHardwareAddressList[existingIdx] == dhcpReq.ClientHardwareAddressAsString)
+                                        {
+                                            // Client was connected before and still holds a valid lease
+                                            yourIp = reqIp.GetAddressBytes();
+                                        }
+                                        // else: IP exists but belongs to a different MAC, fall through to GetFirstAvailableIp()
+                                    }
 
-                                if (yourIp == null)
-                                {
-                                    yourIp = GetFirstAvailableIp();
+                                    if (yourIp == null)
+                                    {
+                                        yourIp = GetFirstAvailableIp();
+                                    }
                                 }
 
                                 dhcpReq.SecondsElapsed = _timeToLeave;
@@ -365,14 +373,14 @@ namespace Iot.Device.DhcpServer
                                                 sendNak = true;
                                             }
                                         }
-                                        else if (!requestedIp.Equals(IPAddress.Any) && !requestedIp.Equals(_ipAddress))
+                                        else if (!requestedIp.Equals(IPAddress.Any) && !requestedIp.Equals(_ipAddress) && IsInSubnet(requestedIp))
                                         {
                                             _dhcpIpList.Add(requestedIp);
                                             _dhcpHardwareAddressList.Add(dhcpReq.ClientHardwareAddressAsString);
                                             _dhcpLastRequest.Add(DateTime.UtcNow);
                                             sendAck = true;
                                         }
-                                        // else: invalid IP, ignore
+                                        // else: invalid or off-subnet IP, ignore
                                     }
 
                                     if (sendAck)

--- a/devices/DhcpServer/DhcpServer.cs
+++ b/devices/DhcpServer/DhcpServer.cs
@@ -271,25 +271,37 @@ namespace Iot.Device.DhcpServer
                                     {
                                         Debug.WriteLine("Received REQUEST without ciaddr, client is INIT-REBOOT");
 
+                                        bool sendAck = false;
                                         lock (_dhcpListLock)
                                         {
-                                            int existingIdx = _dhcpIpList.IndexOf(dhcpReq.RequestedIpAddress);
+                                            int existingIdx = FindLeaseIndex(dhcpReq.RequestedIpAddress);
 
                                             if (existingIdx >= 0)
                                             {
-                                                // Refresh the lease timestamp so the client's reboot does
-                                                // not cause the lease to expire prematurely
-                                                _dhcpLastRequest[existingIdx] = DateTime.UtcNow;
+                                                if ((string)_dhcpHardwareAddressList[existingIdx] == dhcpReq.ClientHardwareAddressAsString)
+                                                {
+                                                    // Refresh the lease timestamp so the client's reboot does
+                                                    // not cause the lease to expire prematurely
+                                                    _dhcpLastRequest[existingIdx] = DateTime.UtcNow;
+                                                    sendAck = true;
+                                                }
+                                                // else: MAC mismatch - silently ignore per RFC 2131 §4.3.2
                                             }
-                                            else
+                                            else if (IsInSubnet(dhcpReq.RequestedIpAddress))
                                             {
+                                                // Client claims a previously held lease; accept if the IP is in our subnet
                                                 _dhcpIpList.Add(dhcpReq.RequestedIpAddress);
                                                 _dhcpHardwareAddressList.Add(dhcpReq.ClientHardwareAddressAsString);
                                                 _dhcpLastRequest.Add(DateTime.UtcNow);
+                                                sendAck = true;
                                             }
+                                            // else: out-of-subnet request, silently ignore
                                         }
 
-                                        _sender.Send(MessageBuilder.CreateAck(dhcpReq, _ipAddress, dhcpReq.RequestedIpAddress, _mask, _options).GetBytes());
+                                        if (sendAck)
+                                        {
+                                            _sender.Send(MessageBuilder.CreateAck(dhcpReq, _ipAddress, dhcpReq.RequestedIpAddress, _mask, _options).GetBytes());
+                                        }
                                     }
                                     else
                                     {
@@ -298,16 +310,7 @@ namespace Iot.Device.DhcpServer
                                         // Find the requested address in the list
                                         lock (_dhcpListLock)
                                         {
-                                            // Find the requested address in the list
-                                            int inc = -1;
-                                            for (int i = 0; i < _dhcpIpList.Count; i++)
-                                            {
-                                                if (((IPAddress)_dhcpIpList[i]).ToString() == dhcpReq.RequestedIpAddress.ToString())
-                                                {
-                                                    inc = i;
-                                                    break;
-                                                }
-                                            }
+                                            int inc = FindLeaseIndex(dhcpReq.RequestedIpAddress);
 
                                             // Verify we found the IP and the hardware address matches
                                             if (inc >= 0 && inc < _dhcpHardwareAddressList.Count)
@@ -342,23 +345,44 @@ namespace Iot.Device.DhcpServer
 
                                     // Track the confirmed lease so INIT-REBOOT and RENEW can find it.
                                     // This must be done here; DISCOVER only offers an IP without committing.
+                                    bool sendAck = false;
+                                    bool sendNak = false;
                                     lock (_dhcpListLock)
                                     {
-                                        int existingIdx = _dhcpIpList.IndexOf(dhcpReq.RequestedIpAddress);
+                                        var requestedIp = dhcpReq.RequestedIpAddress;
+                                        int existingIdx = FindLeaseIndex(requestedIp);
 
                                         if (existingIdx >= 0)
                                         {
-                                            _dhcpLastRequest[existingIdx] = DateTime.UtcNow;
+                                            if ((string)_dhcpHardwareAddressList[existingIdx] == dhcpReq.ClientHardwareAddressAsString)
+                                            {
+                                                _dhcpLastRequest[existingIdx] = DateTime.UtcNow;
+                                                sendAck = true;
+                                            }
+                                            else
+                                            {
+                                                // IP already leased to a different client
+                                                sendNak = true;
+                                            }
                                         }
-                                        else
+                                        else if (!requestedIp.Equals(IPAddress.Any) && !requestedIp.Equals(_ipAddress))
                                         {
-                                            _dhcpIpList.Add(dhcpReq.RequestedIpAddress);
+                                            _dhcpIpList.Add(requestedIp);
                                             _dhcpHardwareAddressList.Add(dhcpReq.ClientHardwareAddressAsString);
                                             _dhcpLastRequest.Add(DateTime.UtcNow);
+                                            sendAck = true;
                                         }
+                                        // else: invalid IP, ignore
                                     }
 
-                                    _sender.Send(MessageBuilder.CreateAck(dhcpReq, _ipAddress, dhcpReq.RequestedIpAddress, _mask, _options).GetBytes());
+                                    if (sendAck)
+                                    {
+                                        _sender.Send(MessageBuilder.CreateAck(dhcpReq, _ipAddress, dhcpReq.RequestedIpAddress, _mask, _options).GetBytes());
+                                    }
+                                    else if (sendNak)
+                                    {
+                                        _sender.Send(MessageBuilder.CreateNak(dhcpReq, _ipAddress).GetBytes());
+                                    }
                                 }
 
                                 break;
@@ -393,6 +417,36 @@ namespace Iot.Device.DhcpServer
             _dhcplistener = null;
             _sender = null;
             Debug.WriteLine($"DHCP: stoped");
+        }
+
+        private int FindLeaseIndex(IPAddress requestedIp)
+        {
+            for (int i = 0; i < _dhcpIpList.Count; i++)
+            {
+                if (((IPAddress)_dhcpIpList[i]).Equals(requestedIp))
+                {
+                    return i;
+                }
+            }
+
+            return -1;
+        }
+
+        private bool IsInSubnet(IPAddress address)
+        {
+            byte[] addrBytes = address.GetAddressBytes();
+            byte[] serverBytes = _ipAddress.GetAddressBytes();
+            byte[] maskBytes = _mask.GetAddressBytes();
+
+            for (int i = 0; i < 4; i++)
+            {
+                if ((addrBytes[i] & maskBytes[i]) != (serverBytes[i] & maskBytes[i]))
+                {
+                    return false;
+                }
+            }
+
+            return true;
         }
 
         private byte[] GetFirstAvailableIp()


### PR DESCRIPTION
## Description
- SELECTING never committed the negotiated lease, causing all subsequent INIT-REBOOT and RENEW requests to fail and trigger redundant DISCOVER cycles.
- INIT-REBOOT also lacked a lock against the cleanup timer thread and never refreshed the lease timestamp on reconnect.
- DISCOVER now guards IP reuse with a Contains() check to avoid offering an already leased address.

## Motivation and Context

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
