### PR TITLE
[HomeAssistant] Don't require double device IDs and auto generate LWT topic

### DIFF
--- a/devices/HomeAssistant/HomeAssistantClient.cs
+++ b/devices/HomeAssistant/HomeAssistantClient.cs
@@ -212,7 +212,7 @@ namespace nanoFramework.HomeAssistant
                     sanitized.Append(c);
                     lastWasSeparator = false;
                 }
-                else if (c == ' ' || c == '-' || c == '_')
+                else if (IsAsciiWhitespace(c) || c == '-' || c == '_')
                 {
                     if (!lastWasSeparator && sanitized.Length > 0)
                     {
@@ -230,6 +230,18 @@ namespace nanoFramework.HomeAssistant
             }
 
             return sanitized.ToString();
+        }
+
+        /// <summary>
+        /// Determines whether <paramref name="c"/> is an ASCII whitespace character (space, tab, newline,
+        /// carriage return, form feed, or vertical tab). nanoFramework's mscorlib does not provide
+        /// <c>Char.IsWhiteSpace</c>, so this enumerates the characters explicitly.
+        /// </summary>
+        /// <param name="c">The character to test.</param>
+        /// <returns><see langword="true"/> if <paramref name="c"/> is ASCII whitespace; otherwise <see langword="false"/>.</returns>
+        private static bool IsAsciiWhitespace(char c)
+        {
+            return c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == '\f' || c == '\v';
         }
 
         /// <summary>

--- a/devices/HomeAssistant/HomeAssistantClient.cs
+++ b/devices/HomeAssistant/HomeAssistantClient.cs
@@ -358,7 +358,13 @@ namespace nanoFramework.HomeAssistant
         /// <returns>The normalized topic segment.</returns>
         private string NormalizeTopicName(string name)
         {
-            return SanitizeTopicSegment(name, '_');
+            string normalized = SanitizeTopicSegment(name, '_');
+            if (normalized.Length == 0)
+            {
+                throw new ArgumentException("Topic name segment must contain at least one alphanumeric character.", nameof(name));
+            }
+
+            return normalized;
         }
 
         /// <summary>

--- a/devices/HomeAssistant/HomeAssistantClient.cs
+++ b/devices/HomeAssistant/HomeAssistantClient.cs
@@ -68,7 +68,7 @@ namespace nanoFramework.HomeAssistant
         /// Initializes a new instance of the <see cref="HomeAssistantClient" /> class.
         /// Configures MQTT broker details and device metadata with auto-generated topics.
         /// </summary>
-        /// <param name="device">Device metadata shared by all entities. Its <see cref="HomeAssistantDeviceInfo.Name"/> is also used to auto-generate MQTT topics (e.g., 'nanoSprinkler').</param>
+        /// <param name="device">Device metadata shared by all entities. Its <see cref="HomeAssistantDeviceInfo.Id"/> is also used to auto-generate MQTT topics (e.g., 'nanoSprinkler-01').</param>
         /// <param name="brokerAddress">MQTT broker IP address or hostname.</param>
         /// <param name="brokerPort">MQTT broker port (usually 1883).</param>
         /// <param name="mqttClientIdPrefix">Prefix for generating unique MQTT client ID.</param>
@@ -77,7 +77,7 @@ namespace nanoFramework.HomeAssistant
         /// <param name="onMqttMessageReceived">Optional event handler for received MQTT messages.</param>
         /// <param name="onMqttConnectionClosed">Optional event handler for MQTT connection closed.</param>
         /// <exception cref="ArgumentNullException">Thrown when <paramref name="device"/> is <c>null</c>.</exception>
-        /// <exception cref="ArgumentException">Thrown when <paramref name="device"/>'s <see cref="HomeAssistantDeviceInfo.Name"/> contains no alphanumeric characters (e.g. it is entirely emoji or punctuation) and cannot be used to generate MQTT topics.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="device"/>'s <see cref="HomeAssistantDeviceInfo.Id"/> contains no alphanumeric characters (e.g. it is entirely emoji or punctuation) and cannot be used to generate MQTT topics.</exception>
         public HomeAssistantClient(
             HomeAssistantDeviceInfo device,
             string brokerAddress,
@@ -93,9 +93,9 @@ namespace nanoFramework.HomeAssistant
                 throw new ArgumentNullException(nameof(device));
             }
 
-            if (SanitizeTopicSegment(device.Name, '-').Length == 0)
+            if (SanitizeTopicSegment(device.Id, '-').Length == 0)
             {
-                throw new ArgumentException("Device name must contain at least one alphanumeric character (a-z, 0-9) to generate MQTT topics.", nameof(device));
+                throw new ArgumentException("Device ID must contain at least one alphanumeric character (a-z, 0-9) to generate MQTT topics.", nameof(device));
             }
 
             _device = device;
@@ -104,7 +104,7 @@ namespace nanoFramework.HomeAssistant
             _mqttClientIdPrefix = mqttClientIdPrefix;
             _mqttUsername = mqttUsername;
             _mqttPassword = mqttPassword;
-            _deviceTopicRoot = GenerateDeviceTopicRoot(_device.Name);
+            _deviceTopicRoot = GenerateDeviceTopicRoot(_device.Id);
             _availabilityTopic = GenerateAvailabilityTopic();
             _discoveryEntities = new ArrayList();
             _runtimeEntities = new ArrayList();
@@ -255,13 +255,13 @@ namespace nanoFramework.HomeAssistant
         }
 
         /// <summary>
-        /// Generates the root topic prefix from a device name.
-        /// Example: 'nanoSprinkler' → 'nanoframework/nano-sprinkler'.
+        /// Generates the root topic prefix from a device ID.
+        /// Example: 'nanoSprinkler-01' → 'nanoframework/nano-sprinkler-01'.
         /// </summary>
         /// <returns>The normalized device topic root.</returns>
-        private string GenerateDeviceTopicRoot(string deviceName)
+        private string GenerateDeviceTopicRoot(string deviceId)
         {
-            string normalized = SanitizeTopicSegment(deviceName, '-');
+            string normalized = SanitizeTopicSegment(deviceId, '-');
             return $"nanoframework/{normalized}";
         }
 

--- a/devices/HomeAssistant/HomeAssistantClient.cs
+++ b/devices/HomeAssistant/HomeAssistantClient.cs
@@ -174,6 +174,63 @@ namespace nanoFramework.HomeAssistant
         }
 
         /// <summary>
+        /// Sanitizes a name into an MQTT-topic-safe segment: lowercase ASCII letters and digits only,
+        /// with whitespace/dashes/underscores collapsed to a single <paramref name="separator"/>.
+        /// Any other character (emoji, punctuation, non-ASCII, MQTT wildcards such as '+' and '#') is dropped,
+        /// since such characters can break topic matching or are not reliably supported end-to-end.
+        /// </summary>
+        /// <param name="value">The raw name to sanitize.</param>
+        /// <param name="separator">The character used to join word segments (e.g. '-' or '_').</param>
+        /// <returns>The sanitized, topic-safe segment.</returns>
+        private static string SanitizeTopicSegment(string value, char separator)
+        {
+            if (string.IsNullOrEmpty(value))
+            {
+                return string.Empty;
+            }
+
+            StringBuilder sanitized = new StringBuilder(value.Length);
+            bool lastWasSeparator = false;
+
+            for (int i = 0; i < value.Length; i++)
+            {
+                char c = value[i];
+                if (c >= 'a' && c <= 'z')
+                {
+                    sanitized.Append(c);
+                    lastWasSeparator = false;
+                }
+                else if (c >= 'A' && c <= 'Z')
+                {
+                    sanitized.Append((char)(c + 32));
+                    lastWasSeparator = false;
+                }
+                else if (c >= '0' && c <= '9')
+                {
+                    sanitized.Append(c);
+                    lastWasSeparator = false;
+                }
+                else if (c == ' ' || c == '-' || c == '_')
+                {
+                    if (!lastWasSeparator && sanitized.Length > 0)
+                    {
+                        sanitized.Append(separator);
+                        lastWasSeparator = true;
+                    }
+                }
+
+                // Any other character (emoji, punctuation, non-ASCII, MQTT wildcards) is dropped.
+            }
+
+            if (sanitized.Length > 0 && sanitized[sanitized.Length - 1] == separator)
+            {
+                sanitized.Length--;
+            }
+
+            return sanitized.ToString();
+        }
+
+        /// <summary>
         /// Generates the availability topic from device name.
         /// Example: 'nanoSprinkler' → 'nanoframework/nano-sprinkler/availability'.
         /// </summary>
@@ -302,63 +359,6 @@ namespace nanoFramework.HomeAssistant
         private string NormalizeTopicName(string name)
         {
             return SanitizeTopicSegment(name, '_');
-        }
-
-        /// <summary>
-        /// Sanitizes a name into an MQTT-topic-safe segment: lowercase ASCII letters and digits only,
-        /// with whitespace/dashes/underscores collapsed to a single <paramref name="separator"/>.
-        /// Any other character (emoji, punctuation, non-ASCII, MQTT wildcards such as '+' and '#') is dropped,
-        /// since such characters can break topic matching or are not reliably supported end-to-end.
-        /// </summary>
-        /// <param name="value">The raw name to sanitize.</param>
-        /// <param name="separator">The character used to join word segments (e.g. '-' or '_').</param>
-        /// <returns>The sanitized, topic-safe segment.</returns>
-        private static string SanitizeTopicSegment(string value, char separator)
-        {
-            if (string.IsNullOrEmpty(value))
-            {
-                return string.Empty;
-            }
-
-            StringBuilder sanitized = new StringBuilder(value.Length);
-            bool lastWasSeparator = false;
-
-            for (int i = 0; i < value.Length; i++)
-            {
-                char c = value[i];
-                if (c >= 'a' && c <= 'z')
-                {
-                    sanitized.Append(c);
-                    lastWasSeparator = false;
-                }
-                else if (c >= 'A' && c <= 'Z')
-                {
-                    sanitized.Append((char)(c + 32));
-                    lastWasSeparator = false;
-                }
-                else if (c >= '0' && c <= '9')
-                {
-                    sanitized.Append(c);
-                    lastWasSeparator = false;
-                }
-                else if (c == ' ' || c == '-' || c == '_')
-                {
-                    if (!lastWasSeparator && sanitized.Length > 0)
-                    {
-                        sanitized.Append(separator);
-                        lastWasSeparator = true;
-                    }
-                }
-
-                // Any other character (emoji, punctuation, non-ASCII, MQTT wildcards) is dropped.
-            }
-
-            if (sanitized.Length > 0 && sanitized[sanitized.Length - 1] == separator)
-            {
-                sanitized.Length--;
-            }
-
-            return sanitized.ToString();
         }
 
         /// <summary>
@@ -769,7 +769,7 @@ namespace nanoFramework.HomeAssistant
         /// <summary>
         /// Connects to the MQTT broker and publishes discovery configuration.
         /// </summary>
-        /// <param name="willTopic">Topic for last-will-testament message (usually availability topic).</param>
+        /// <param name="willTopic">Topic for the last-will-testament message. When <c>null</c> (the default), auto-generated from the device name via <see cref="AvailabilityTopic"/>. Pass <see cref="string.Empty"/> to connect without an LWT.</param>
         /// <param name="willMessage">Payload for LWT (usually "offline").</param>
         /// <returns>True if connection successful, false otherwise.</returns>
         public bool Connect(string willTopic = null, string willMessage = "offline")
@@ -789,8 +789,12 @@ namespace nanoFramework.HomeAssistant
 
                     clientId = _mqttClientIdPrefix + Guid.NewGuid().ToString();
 
-                    // Connect with LWT if provided
-                    if (!string.IsNullOrEmpty(willTopic))
+                    // Auto-generate the will topic from the device name unless the caller overrode it
+                    // (or explicitly opted out of an LWT by passing string.Empty).
+                    string effectiveWillTopic = willTopic ?? GenerateAvailabilityTopic();
+
+                    // Connect with LWT if a will topic is in effect
+                    if (!string.IsNullOrEmpty(effectiveWillTopic))
                     {
                         client.Connect(
                             clientId,
@@ -799,7 +803,7 @@ namespace nanoFramework.HomeAssistant
                             willRetain: true,
                             willQosLevel: MqttQoSLevel.AtLeastOnce,
                             willFlag: true,
-                            willTopic: willTopic,
+                            willTopic: effectiveWillTopic,
                             willMessage: willMessage,
                             cleanSession: true,
                             keepAlivePeriod: 60);

--- a/devices/HomeAssistant/HomeAssistantClient.cs
+++ b/devices/HomeAssistant/HomeAssistantClient.cs
@@ -68,7 +68,7 @@ namespace nanoFramework.HomeAssistant
         /// Initializes a new instance of the <see cref="HomeAssistantClient" /> class.
         /// Configures MQTT broker details and device metadata with auto-generated topics.
         /// </summary>
-        /// <param name="device">Device metadata shared by all entities. Its <see cref="HomeAssistantDeviceInfo.Id"/> is also used to auto-generate MQTT topics (e.g., 'nanoSprinkler-01').</param>
+        /// <param name="device">Device metadata shared by all entities. Its <see cref="HomeAssistantDeviceInfo.Id"/> is also used to auto-generate MQTT topics (e.g., 'nanoSprinkler-01'). <see cref="HomeAssistantDeviceInfo.Id"/> must contain at least one alphanumeric character (a-z, 0-9) to generate MQTT topics.</param>
         /// <param name="brokerAddress">MQTT broker IP address or hostname.</param>
         /// <param name="brokerPort">MQTT broker port (usually 1883).</param>
         /// <param name="mqttClientIdPrefix">Prefix for generating unique MQTT client ID.</param>
@@ -95,7 +95,7 @@ namespace nanoFramework.HomeAssistant
 
             if (SanitizeTopicSegment(device.Id, '-').Length == 0)
             {
-                throw new ArgumentException("Device ID must contain at least one alphanumeric character (a-z, 0-9) to generate MQTT topics.", nameof(device));
+                throw new ArgumentException();
             }
 
             _device = device;

--- a/devices/HomeAssistant/HomeAssistantClient.cs
+++ b/devices/HomeAssistant/HomeAssistantClient.cs
@@ -77,7 +77,7 @@ namespace nanoFramework.HomeAssistant
         /// <param name="onMqttMessageReceived">Optional event handler for received MQTT messages.</param>
         /// <param name="onMqttConnectionClosed">Optional event handler for MQTT connection closed.</param>
         /// <exception cref="ArgumentNullException">Thrown when <paramref name="device"/> is <c>null</c>.</exception>
-        /// <exception cref="ArgumentException">Thrown when <paramref name="device"/>'s <see cref="HomeAssistantDeviceInfo.Id"/> contains no alphanumeric characters (e.g. it is entirely emoji or punctuation) and cannot be used to generate MQTT topics.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="device"/>'s <see cref="HomeAssistantDeviceInfo.Id"/> contains no alphanumeric characters (e.g. it is entirely emoji or punctuation), or contains a character that cannot be represented in an MQTT topic segment (e.g. emoji, punctuation, non-ASCII, or MQTT wildcards such as '+' and '#'), and cannot be used to generate MQTT topics.</exception>
         public HomeAssistantClient(
             HomeAssistantDeviceInfo device,
             string brokerAddress,
@@ -122,7 +122,8 @@ namespace nanoFramework.HomeAssistant
         }
 
         /// <summary>
-        /// Gets the device name used for auto-generating MQTT topics.
+        /// Gets the display name of the device. MQTT topics are generated from
+        /// <see cref="HomeAssistantDeviceInfo.Id"/>, not from this name.
         /// </summary>
         public string DeviceName
         {
@@ -178,12 +179,16 @@ namespace nanoFramework.HomeAssistant
         /// <summary>
         /// Sanitizes a name into an MQTT-topic-safe segment: lowercase ASCII letters and digits only,
         /// with whitespace/dashes/underscores collapsed to a single <paramref name="separator"/>.
-        /// Any other character (emoji, punctuation, non-ASCII, MQTT wildcards such as '+' and '#') is dropped,
-        /// since such characters can break topic matching or are not reliably supported end-to-end.
+        /// Any other character (emoji, punctuation, non-ASCII, MQTT wildcards such as '+' and '#') is rejected
+        /// rather than dropped, so that distinct inputs (e.g. "dev/1" and "dev1") cannot silently collapse
+        /// onto the same topic segment.
         /// </summary>
         /// <param name="value">The raw name to sanitize.</param>
         /// <param name="separator">The character used to join word segments (e.g. '-' or '_').</param>
         /// <returns>The sanitized, topic-safe segment.</returns>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="value"/> contains a character that
+        /// cannot be represented in a topic segment (e.g. emoji, punctuation, non-ASCII, or MQTT wildcards such
+        /// as '+' and '#').</exception>
         private static string SanitizeTopicSegment(string value, char separator)
         {
             if (string.IsNullOrEmpty(value))
@@ -220,8 +225,10 @@ namespace nanoFramework.HomeAssistant
                         lastWasSeparator = true;
                     }
                 }
-
-                // Any other character (emoji, punctuation, non-ASCII, MQTT wildcards) is dropped.
+                else
+                {
+                    throw new ArgumentException();
+                }
             }
 
             if (sanitized.Length > 0 && sanitized[sanitized.Length - 1] == separator)
@@ -245,8 +252,8 @@ namespace nanoFramework.HomeAssistant
         }
 
         /// <summary>
-        /// Generates the availability topic from device name.
-        /// Example: 'nanoSprinkler' → 'nanoframework/nano-sprinkler/availability'.
+        /// Generates the availability topic from the device ID.
+        /// Example: device.Id='nanoSprinkler' → 'nanoframework/nanosprinkler/availability'.
         /// </summary>
         /// <returns>The availability topic for the configured device.</returns>
         private string GenerateAvailabilityTopic()
@@ -256,7 +263,7 @@ namespace nanoFramework.HomeAssistant
 
         /// <summary>
         /// Generates the root topic prefix from a device ID.
-        /// Example: 'nanoSprinkler-01' → 'nanoframework/nano-sprinkler-01'.
+        /// Example: 'nanoSprinkler-01' → 'nanoframework/nanosprinkler-01'.
         /// </summary>
         /// <returns>The normalized device topic root.</returns>
         private string GenerateDeviceTopicRoot(string deviceId)
@@ -284,10 +291,11 @@ namespace nanoFramework.HomeAssistant
         }
 
         /// <summary>
-        /// Generates command topic for an entity based on its name and device name.
-        /// Normalizes both device name and entity name to lowercase with dashes.
-        /// Example: deviceName='nanoSprinkler', entityName='Timer ON Seconds'.
-        /// → 'nanoframework/nano-sprinkler/timer-on-seconds/set'.
+        /// Generates command topic for an entity based on its name and the device ID.
+        /// The device topic root is normalized with '-' as the word separator; entity name
+        /// segments are normalized with '_'.
+        /// Example: device.Id='nanoSprinkler', entityName='Timer ON Seconds'.
+        /// → 'nanoframework/nanosprinkler/timer_on_seconds/set'.
         /// </summary>
         /// <returns>The generated command topic for the entity, or the root command topic when name is empty.</returns>
         public string GenerateCommandTopic(string entityName)
@@ -303,8 +311,8 @@ namespace nanoFramework.HomeAssistant
 
         /// <summary>
         /// Generates command topic for an entity with a command channel suffix.
-        /// Example: deviceName='nanoSprinkler', entityName='Thermostat', commandSuffix='mode'.
-        /// → 'nanoframework/nano-sprinkler/thermostat/mode/set'.
+        /// Example: device.Id='nanoSprinkler', entityName='Thermostat', commandSuffix='mode'.
+        /// → 'nanoframework/nanosprinkler/thermostat/mode/set'.
         /// </summary>
         /// <returns>The generated command topic with suffix channel.</returns>
         public string GenerateCommandTopic(string entityName, string commandSuffix)
@@ -326,9 +334,9 @@ namespace nanoFramework.HomeAssistant
         }
 
         /// <summary>
-        /// Generates state topic for an entity based on its name and device name.
-        /// Example: deviceName='nanoSprinkler', entityName='Timer'.
-        /// → 'nanoframework/nano-sprinkler/timer/state'.
+        /// Generates state topic for an entity based on its name and the device ID.
+        /// Example: device.Id='nanoSprinkler', entityName='Timer'.
+        /// → 'nanoframework/nanosprinkler/timer/state'.
         /// </summary>
         /// <returns>The generated state topic for the entity, or the root state topic when name is empty.</returns>
         public string GenerateStateTopic(string entityName)
@@ -344,8 +352,8 @@ namespace nanoFramework.HomeAssistant
 
         /// <summary>
         /// Generates state topic for an entity with a state channel suffix.
-        /// Example: deviceName='nanoSprinkler', entityName='Thermostat', stateSuffix='temperature'.
-        /// → 'nanoframework/nano-sprinkler/thermostat/temperature/state'.
+        /// Example: device.Id='nanoSprinkler', entityName='Thermostat', stateSuffix='temperature'.
+        /// → 'nanoframework/nanosprinkler/thermostat/temperature/state'.
         /// </summary>
         /// <returns>The generated state topic with suffix channel.</returns>
         public string GenerateStateTopic(string entityName, string stateSuffix)
@@ -367,7 +375,8 @@ namespace nanoFramework.HomeAssistant
         }
 
         /// <summary>
-        /// Normalizes entity name to topic format (lowercase, spaces to underscores).
+        /// Normalizes an entity name into a topic-safe segment: lowercase ASCII, with
+        /// whitespace/dashes/underscores collapsed to a single underscore.
         /// </summary>
         /// <returns>The normalized topic segment.</returns>
         private string NormalizeTopicName(string name)
@@ -789,7 +798,7 @@ namespace nanoFramework.HomeAssistant
         /// <summary>
         /// Connects to the MQTT broker and publishes discovery configuration.
         /// </summary>
-        /// <param name="willTopic">Topic for the last-will-testament message. When <c>null</c> (the default), auto-generated from the device name. Pass <see cref="string.Empty"/> to connect without an LWT (availability publishing still uses the default topic). A non-empty custom value also becomes <see cref="AvailabilityTopic"/> for this session, so <see cref="PublishOnline"/>, <see cref="Disconnect"/>, and discovery payloads stay consistent with the broker's LWT topic.</param>
+        /// <param name="willTopic">Topic for the last-will-testament message. When <c>null</c> (the default), auto-generated from the device ID. Pass <see cref="string.Empty"/> to connect without an LWT (availability publishing still uses the default topic). A non-empty custom value also becomes <see cref="AvailabilityTopic"/> for this session, so <see cref="PublishOnline"/>, <see cref="Disconnect"/>, and discovery payloads stay consistent with the broker's LWT topic.</param>
         /// <param name="willMessage">Payload for LWT (usually "offline").</param>
         /// <returns>True if connection successful, false otherwise.</returns>
         public bool Connect(string willTopic = null, string willMessage = "offline")
@@ -809,7 +818,7 @@ namespace nanoFramework.HomeAssistant
 
                     clientId = _mqttClientIdPrefix + Guid.NewGuid().ToString();
 
-                    // Auto-generate the will topic from the device name unless the caller overrode it
+                    // Auto-generate the will topic from the device ID unless the caller overrode it
                     // (or explicitly opted out of an LWT by passing string.Empty).
                     string effectiveWillTopic = willTopic ?? GenerateAvailabilityTopic();
 
@@ -1043,7 +1052,10 @@ namespace nanoFramework.HomeAssistant
         /// </summary>
         public void PublishOnline()
         {
-            PublishRetained(_availabilityTopic, "online");
+            lock (_mqttLock)
+            {
+                PublishRetained(_availabilityTopic, "online");
+            }
         }
 
         /// <summary>
@@ -1051,7 +1063,10 @@ namespace nanoFramework.HomeAssistant
         /// </summary>
         public void PublishOffline()
         {
-            PublishRetained(_availabilityTopic, "offline");
+            lock (_mqttLock)
+            {
+                PublishRetained(_availabilityTopic, "offline");
+            }
         }
 
         /// <summary>
@@ -1064,35 +1079,38 @@ namespace nanoFramework.HomeAssistant
                 return;
             }
 
-            string deviceFull = _device == null ? null : _device.ToFullJson();
-            string deviceRef = _device == null ? null : _device.ToReferenceJson();
-            bool fullDevicePublished = false;
-
-            for (int i = 0; i < _discoveryEntities.Count; i++)
+            lock (_mqttLock)
             {
-                HomeAssistantDiscoveryEntity entity = (HomeAssistantDiscoveryEntity)_discoveryEntities[i];
-                if (entity == null)
-                {
-                    continue;
-                }
+                string deviceFull = _device == null ? null : _device.ToFullJson();
+                string deviceRef = _device == null ? null : _device.ToReferenceJson();
+                bool fullDevicePublished = false;
 
-                string deviceJson = null;
-                if (entity.IncludeDevice && _device != null)
+                for (int i = 0; i < _discoveryEntities.Count; i++)
                 {
-                    if (!fullDevicePublished && entity.PreferFullDevice)
+                    HomeAssistantDiscoveryEntity entity = (HomeAssistantDiscoveryEntity)_discoveryEntities[i];
+                    if (entity == null)
                     {
-                        deviceJson = deviceFull;
-                        fullDevicePublished = true;
+                        continue;
                     }
-                    else
-                    {
-                        deviceJson = deviceRef;
-                    }
-                }
 
-                string topic = entity.BuildDiscoveryTopic(HomeAssistantTopics.DiscoveryPrefix);
-                string payload = entity.BuildConfigPayload(_availabilityTopic, deviceJson);
-                PublishRetained(topic, payload);
+                    string deviceJson = null;
+                    if (entity.IncludeDevice && _device != null)
+                    {
+                        if (!fullDevicePublished && entity.PreferFullDevice)
+                        {
+                            deviceJson = deviceFull;
+                            fullDevicePublished = true;
+                        }
+                        else
+                        {
+                            deviceJson = deviceRef;
+                        }
+                    }
+
+                    string topic = entity.BuildDiscoveryTopic(HomeAssistantTopics.DiscoveryPrefix);
+                    string payload = entity.BuildConfigPayload(_availabilityTopic, deviceJson);
+                    PublishRetained(topic, payload);
+                }
             }
         }
 
@@ -1301,15 +1319,18 @@ namespace nanoFramework.HomeAssistant
                 return;
             }
 
-            string deviceJson = null;
-            if (entity.IncludeDevice && _device != null)
+            lock (_mqttLock)
             {
-                deviceJson = entity.PreferFullDevice ? _device.ToFullJson() : _device.ToReferenceJson();
-            }
+                string deviceJson = null;
+                if (entity.IncludeDevice && _device != null)
+                {
+                    deviceJson = entity.PreferFullDevice ? _device.ToFullJson() : _device.ToReferenceJson();
+                }
 
-            string topic = entity.BuildDiscoveryTopic(HomeAssistantTopics.DiscoveryPrefix);
-            string payload = entity.BuildConfigPayload(_availabilityTopic, deviceJson);
-            PublishRetained(topic, payload);
+                string topic = entity.BuildDiscoveryTopic(HomeAssistantTopics.DiscoveryPrefix);
+                string payload = entity.BuildConfigPayload(_availabilityTopic, deviceJson);
+                PublishRetained(topic, payload);
+            }
         }
 
         private void SubscribeEntityCommandTopics(HomeAssistantRuntimeEntity entity)

--- a/devices/HomeAssistant/HomeAssistantClient.cs
+++ b/devices/HomeAssistant/HomeAssistantClient.cs
@@ -31,7 +31,6 @@ namespace nanoFramework.HomeAssistant
         /// <param name="e">MQTT publish acknowledgment arguments.</param>
         public delegate void MqttMessagePublishedHandler(object sender, MqttMsgPublishedEventArgs e);
 
-        private readonly string _deviceName;
         private readonly HomeAssistantDeviceInfo _device;
         private readonly string _brokerAddress;
         private readonly int _brokerPort;
@@ -68,8 +67,7 @@ namespace nanoFramework.HomeAssistant
         /// Initializes a new instance of the <see cref="HomeAssistantClient" /> class.
         /// Configures MQTT broker details and device metadata with auto-generated topics.
         /// </summary>
-        /// <param name="deviceName">Device name used to auto-generate MQTT topics (e.g., 'nanoSprinkler').</param>
-        /// <param name="device">Device metadata shared by all entities.</param>
+        /// <param name="device">Device metadata shared by all entities. Its <see cref="HomeAssistantDeviceInfo.Name"/> is also used to auto-generate MQTT topics (e.g., 'nanoSprinkler').</param>
         /// <param name="brokerAddress">MQTT broker IP address or hostname.</param>
         /// <param name="brokerPort">MQTT broker port (usually 1883).</param>
         /// <param name="mqttClientIdPrefix">Prefix for generating unique MQTT client ID.</param>
@@ -77,8 +75,9 @@ namespace nanoFramework.HomeAssistant
         /// <param name="mqttPassword">Optional MQTT broker password.</param>
         /// <param name="onMqttMessageReceived">Optional event handler for received MQTT messages.</param>
         /// <param name="onMqttConnectionClosed">Optional event handler for MQTT connection closed.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="device"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="device"/>'s <see cref="HomeAssistantDeviceInfo.Name"/> contains no alphanumeric characters (e.g. it is entirely emoji or punctuation) and cannot be used to generate MQTT topics.</exception>
         public HomeAssistantClient(
-            string deviceName,
             HomeAssistantDeviceInfo device,
             string brokerAddress,
             int brokerPort,
@@ -88,14 +87,23 @@ namespace nanoFramework.HomeAssistant
             MqttMessageReceivedHandler onMqttMessageReceived = null,
             EventHandler onMqttConnectionClosed = null)
         {
-            _deviceName = deviceName;
+            if (device == null)
+            {
+                throw new ArgumentNullException(nameof(device));
+            }
+
+            if (SanitizeTopicSegment(device.Name, '-').Length == 0)
+            {
+                throw new ArgumentException("Device name must contain at least one alphanumeric character (a-z, 0-9) to generate MQTT topics.", nameof(device));
+            }
+
             _device = device;
             _brokerAddress = brokerAddress;
             _brokerPort = brokerPort;
             _mqttClientIdPrefix = mqttClientIdPrefix;
             _mqttUsername = mqttUsername;
             _mqttPassword = mqttPassword;
-            _deviceTopicRoot = GenerateDeviceTopicRoot(_deviceName);
+            _deviceTopicRoot = GenerateDeviceTopicRoot(_device.Name);
             _discoveryEntities = new ArrayList();
             _runtimeEntities = new ArrayList();
 
@@ -116,7 +124,7 @@ namespace nanoFramework.HomeAssistant
         /// </summary>
         public string DeviceName
         {
-            get { return _deviceName; }
+            get { return _device.Name; }
         }
 
         /// <summary>
@@ -182,7 +190,7 @@ namespace nanoFramework.HomeAssistant
         /// <returns>The normalized device topic root.</returns>
         private string GenerateDeviceTopicRoot(string deviceName)
         {
-            string normalized = (deviceName ?? string.Empty).Replace(" ", "-").ToLower();
+            string normalized = SanitizeTopicSegment(deviceName, '-');
             return $"nanoframework/{normalized}";
         }
 
@@ -293,33 +301,64 @@ namespace nanoFramework.HomeAssistant
         /// <returns>The normalized topic segment.</returns>
         private string NormalizeTopicName(string name)
         {
-            if (string.IsNullOrEmpty(name))
+            return SanitizeTopicSegment(name, '_');
+        }
+
+        /// <summary>
+        /// Sanitizes a name into an MQTT-topic-safe segment: lowercase ASCII letters and digits only,
+        /// with whitespace/dashes/underscores collapsed to a single <paramref name="separator"/>.
+        /// Any other character (emoji, punctuation, non-ASCII, MQTT wildcards such as '+' and '#') is dropped,
+        /// since such characters can break topic matching or are not reliably supported end-to-end.
+        /// </summary>
+        /// <param name="value">The raw name to sanitize.</param>
+        /// <param name="separator">The character used to join word segments (e.g. '-' or '_').</param>
+        /// <returns>The sanitized, topic-safe segment.</returns>
+        private static string SanitizeTopicSegment(string value, char separator)
+        {
+            if (string.IsNullOrEmpty(value))
             {
                 return string.Empty;
             }
 
-            StringBuilder normalized = new StringBuilder(name.Length);
-            bool lastWasSpace = false;
+            StringBuilder sanitized = new StringBuilder(value.Length);
+            bool lastWasSeparator = false;
 
-            for (int i = 0; i < name.Length; i++)
+            for (int i = 0; i < value.Length; i++)
             {
-                char c = name[i];
-                if (c == ' ')
+                char c = value[i];
+                if (c >= 'a' && c <= 'z')
                 {
-                    if (!lastWasSpace && normalized.Length > 0)
+                    sanitized.Append(c);
+                    lastWasSeparator = false;
+                }
+                else if (c >= 'A' && c <= 'Z')
+                {
+                    sanitized.Append((char)(c + 32));
+                    lastWasSeparator = false;
+                }
+                else if (c >= '0' && c <= '9')
+                {
+                    sanitized.Append(c);
+                    lastWasSeparator = false;
+                }
+                else if (c == ' ' || c == '-' || c == '_')
+                {
+                    if (!lastWasSeparator && sanitized.Length > 0)
                     {
-                        normalized.Append('_');
-                        lastWasSpace = true;
+                        sanitized.Append(separator);
+                        lastWasSeparator = true;
                     }
                 }
-                else
-                {
-                    normalized.Append(c.ToLower());
-                    lastWasSpace = false;
-                }
+
+                // Any other character (emoji, punctuation, non-ASCII, MQTT wildcards) is dropped.
             }
 
-            return normalized.ToString();
+            if (sanitized.Length > 0 && sanitized[sanitized.Length - 1] == separator)
+            {
+                sanitized.Length--;
+            }
+
+            return sanitized.ToString();
         }
 
         /// <summary>

--- a/devices/HomeAssistant/HomeAssistantClient.cs
+++ b/devices/HomeAssistant/HomeAssistantClient.cs
@@ -40,6 +40,7 @@ namespace nanoFramework.HomeAssistant
         private readonly string _deviceTopicRoot;
         private readonly ArrayList _discoveryEntities;
         private readonly ArrayList _runtimeEntities;
+        private string _availabilityTopic;
         private MqttClient _mqttClient;
         private object _mqttLock = new object();
 
@@ -104,6 +105,7 @@ namespace nanoFramework.HomeAssistant
             _mqttUsername = mqttUsername;
             _mqttPassword = mqttPassword;
             _deviceTopicRoot = GenerateDeviceTopicRoot(_device.Name);
+            _availabilityTopic = GenerateAvailabilityTopic();
             _discoveryEntities = new ArrayList();
             _runtimeEntities = new ArrayList();
 
@@ -136,11 +138,11 @@ namespace nanoFramework.HomeAssistant
         }
 
         /// <summary>
-        /// Gets the MQTT availability topic, auto-generated from device name.
+        /// Gets the MQTT availability topic used for online/offline publishing and discovery payloads.
         /// </summary>
         public string AvailabilityTopic
         {
-            get { return GenerateAvailabilityTopic(); }
+            get { return _availabilityTopic; }
         }
 
         /// <summary>
@@ -775,7 +777,7 @@ namespace nanoFramework.HomeAssistant
         /// <summary>
         /// Connects to the MQTT broker and publishes discovery configuration.
         /// </summary>
-        /// <param name="willTopic">Topic for the last-will-testament message. When <c>null</c> (the default), auto-generated from the device name via <see cref="AvailabilityTopic"/>. Pass <see cref="string.Empty"/> to connect without an LWT.</param>
+        /// <param name="willTopic">Topic for the last-will-testament message. When <c>null</c> (the default), auto-generated from the device name. Pass <see cref="string.Empty"/> to connect without an LWT (availability publishing still uses the default topic). A non-empty custom value also becomes <see cref="AvailabilityTopic"/> for this session, so <see cref="PublishOnline"/>, <see cref="Disconnect"/>, and discovery payloads stay consistent with the broker's LWT topic.</param>
         /// <param name="willMessage">Payload for LWT (usually "offline").</param>
         /// <returns>True if connection successful, false otherwise.</returns>
         public bool Connect(string willTopic = null, string willMessage = "offline")
@@ -798,6 +800,8 @@ namespace nanoFramework.HomeAssistant
                     // Auto-generate the will topic from the device name unless the caller overrode it
                     // (or explicitly opted out of an LWT by passing string.Empty).
                     string effectiveWillTopic = willTopic ?? GenerateAvailabilityTopic();
+
+                    _availabilityTopic = string.IsNullOrEmpty(effectiveWillTopic) ? GenerateAvailabilityTopic() : effectiveWillTopic;
 
                     // Connect with LWT if a will topic is in effect
                     if (!string.IsNullOrEmpty(effectiveWillTopic))
@@ -901,7 +905,7 @@ namespace nanoFramework.HomeAssistant
                         try
                         {
                             // Publish offline explicitly before disconnect
-                            PublishRetained(GenerateAvailabilityTopic(), "offline");
+                            PublishRetained(_availabilityTopic, "offline");
                             _mqttClient.Disconnect();
                         }
                         catch (Exception ex)
@@ -1027,7 +1031,7 @@ namespace nanoFramework.HomeAssistant
         /// </summary>
         public void PublishOnline()
         {
-            PublishRetained(GenerateAvailabilityTopic(), "online");
+            PublishRetained(_availabilityTopic, "online");
         }
 
         /// <summary>
@@ -1035,7 +1039,7 @@ namespace nanoFramework.HomeAssistant
         /// </summary>
         public void PublishOffline()
         {
-            PublishRetained(GenerateAvailabilityTopic(), "offline");
+            PublishRetained(_availabilityTopic, "offline");
         }
 
         /// <summary>
@@ -1075,7 +1079,7 @@ namespace nanoFramework.HomeAssistant
                 }
 
                 string topic = entity.BuildDiscoveryTopic(HomeAssistantTopics.DiscoveryPrefix);
-                string payload = entity.BuildConfigPayload(GenerateAvailabilityTopic(), deviceJson);
+                string payload = entity.BuildConfigPayload(_availabilityTopic, deviceJson);
                 PublishRetained(topic, payload);
             }
         }
@@ -1292,7 +1296,7 @@ namespace nanoFramework.HomeAssistant
             }
 
             string topic = entity.BuildDiscoveryTopic(HomeAssistantTopics.DiscoveryPrefix);
-            string payload = entity.BuildConfigPayload(GenerateAvailabilityTopic(), deviceJson);
+            string payload = entity.BuildConfigPayload(_availabilityTopic, deviceJson);
             PublishRetained(topic, payload);
         }
 

--- a/devices/HomeAssistant/HomeAssistantDeviceInfo.cs
+++ b/devices/HomeAssistant/HomeAssistantDeviceInfo.cs
@@ -11,9 +11,6 @@ namespace nanoFramework.HomeAssistant
     /// </summary>
     public sealed class HomeAssistantDeviceInfo
     {
-        private string _id;
-        private string _name;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="HomeAssistantDeviceInfo" /> class.
         /// </summary>
@@ -24,6 +21,16 @@ namespace nanoFramework.HomeAssistant
         /// <exception cref="ArgumentException">Thrown when <paramref name="id"/> or <paramref name="name"/> is null or empty.</exception>
         public HomeAssistantDeviceInfo(string id, string name, string model = null, string manufacturer = null)
         {
+            if (string.IsNullOrEmpty(id))
+            {
+                throw new ArgumentException("Device id cannot be null or empty.");
+            }
+
+            if (string.IsNullOrEmpty(name))
+            {
+                throw new ArgumentException("Device name cannot be null or empty.");
+            }
+
             Id = id;
             Name = name;
             Model = model ?? string.Empty;
@@ -31,58 +38,24 @@ namespace nanoFramework.HomeAssistant
         }
 
         /// <summary>
-        /// Gets or sets the device identifier shared by all entities.
+        /// Gets the device identifier shared by all entities.
         /// </summary>
-        /// <exception cref="ArgumentException">Thrown when value is null or empty.</exception>
-        public string Id
-        {
-            get
-            {
-                return _id;
-            }
-
-            set
-            {
-                if (string.IsNullOrEmpty(value))
-                {
-                    throw new ArgumentException("Device id cannot be null or empty.");
-                }
-
-                _id = value;
-            }
-        }
+        public string Id { get; }
 
         /// <summary>
-        /// Gets or sets the device display name.
+        /// Gets the device display name.
         /// </summary>
-        /// <exception cref="ArgumentException">Thrown when value is null or empty.</exception>
-        public string Name
-        {
-            get
-            {
-                return _name;
-            }
-
-            set
-            {
-                if (string.IsNullOrEmpty(value))
-                {
-                    throw new ArgumentException("Device name cannot be null or empty.");
-                }
-
-                _name = value;
-            }
-        }
+        public string Name { get; }
 
         /// <summary>
-        /// Gets or sets the device model name.
+        /// Gets the device model name.
         /// </summary>
-        public string Model { get; set; }
+        public string Model { get; }
 
         /// <summary>
-        /// Gets or sets the device manufacturer.
+        /// Gets the device manufacturer.
         /// </summary>
-        public string Manufacturer { get; set; }
+        public string Manufacturer { get; }
 
         /// <summary>
         /// Builds a full Home Assistant device JSON object.

--- a/devices/HomeAssistant/HomeAssistantDeviceInfo.cs
+++ b/devices/HomeAssistant/HomeAssistantDeviceInfo.cs
@@ -14,8 +14,8 @@ namespace nanoFramework.HomeAssistant
         /// <summary>
         /// Initializes a new instance of the <see cref="HomeAssistantDeviceInfo" /> class.
         /// </summary>
-        /// <param name="id">Device identifier shared by all entities.</param>
-        /// <param name="name">Device display name.</param>
+        /// <param name="id">Device identifier shared by all entities. Device id cannot be null or empty.</param>
+        /// <param name="name">Device display name. Device name cannot be null or empty.</param>
         /// <param name="model">Device model name.</param>
         /// <param name="manufacturer">Device manufacturer.</param>
         /// <exception cref="ArgumentException">Thrown when <paramref name="id"/> or <paramref name="name"/> is null or empty.</exception>
@@ -23,12 +23,12 @@ namespace nanoFramework.HomeAssistant
         {
             if (string.IsNullOrEmpty(id))
             {
-                throw new ArgumentException("Device id cannot be null or empty.");
+                throw new ArgumentException();
             }
 
             if (string.IsNullOrEmpty(name))
             {
-                throw new ArgumentException("Device name cannot be null or empty.");
+                throw new ArgumentException();
             }
 
             Id = id;

--- a/devices/HomeAssistant/README.md
+++ b/devices/HomeAssistant/README.md
@@ -112,7 +112,7 @@ if (connected)
 }
 ```
 
-`Connect()` automatically sets a Last-Will-Testament on `client.AvailabilityTopic` (payload `"offline"`), so Home Assistant marks the device unavailable if it disconnects ungracefully. Pass a different topic to `willTopic` to override it, or `string.Empty` to connect without an LWT at all.
+`Connect()` automatically sets a Last-Will-Testament on `client.AvailabilityTopic` (payload `"offline"`), so Home Assistant marks the device unavailable if it disconnects ungracefully. Pass a different topic to `willTopic` to override it — `client.AvailabilityTopic` then reflects that custom topic for the rest of the session, so `PublishOnline()`, `Disconnect()`, and discovery payloads all stay consistent with the broker's LWT topic. Pass `string.Empty` to connect without an LWT at all (availability publishing still uses the default topic in that case).
 
 ### 6. Publish state updates
 

--- a/devices/HomeAssistant/README.md
+++ b/devices/HomeAssistant/README.md
@@ -101,8 +101,7 @@ brightness.OnStateChange += (sender, oldState, newState) =>
 ### 5. Connect and publish
 
 ```csharp
-string availabilityTopic = client.AvailabilityTopic;
-bool connected = client.Connect(willTopic: availabilityTopic, willMessage: "offline");
+bool connected = client.Connect();
 
 if (connected)
 {
@@ -112,6 +111,8 @@ if (connected)
     temperature.PublishState("21.5");
 }
 ```
+
+`Connect()` automatically sets a Last-Will-Testament on `client.AvailabilityTopic` (payload `"offline"`), so Home Assistant marks the device unavailable if it disconnects ungracefully. Pass a different topic to `willTopic` to override it, or `string.Empty` to connect without an LWT at all.
 
 ### 6. Publish state updates
 

--- a/devices/HomeAssistant/README.md
+++ b/devices/HomeAssistant/README.md
@@ -27,7 +27,6 @@ var device = new HomeAssistantDeviceInfo(
 
 ```csharp
 var client = new HomeAssistantClient(
-    deviceName:           "MyDevice",
     device:               device,
     brokerAddress:        "192.168.1.2",
     brokerPort:           1883,
@@ -36,8 +35,8 @@ var client = new HomeAssistantClient(
     mqttPassword:         null);   // optional
 ```
 
-The device name is normalized to lowercase with dashes and becomes the root MQTT topic prefix:
-`MyDevice` → `nanoframework/mydevice/…`
+The device's `Name` (from `HomeAssistantDeviceInfo`) is normalized to lowercase with dashes and becomes the root MQTT topic prefix:
+`My Device` → `nanoframework/my-device/…`
 
 ### 3. Add entities
 

--- a/devices/HomeAssistant/samples/Program.cs
+++ b/devices/HomeAssistant/samples/Program.cs
@@ -638,7 +638,6 @@ namespace nanoSprinkler
             string mqttClientIdPrefix = deviceId + "-";
 
             _homeAssistant = new HomeAssistantClient(
-                deviceName,
                 device,
                 _config.MqttBroker,
                 _config.MqttPort,

--- a/devices/HomeAssistant/samples/Program.cs
+++ b/devices/HomeAssistant/samples/Program.cs
@@ -830,8 +830,8 @@ namespace nanoSprinkler
 
             try
             {
-                // Connect to MQTT broker with LWT (Last Will Testament) for availability topic.
-                bool connected = _homeAssistant.Connect(_homeAssistant.AvailabilityTopic, "offline");
+                // Connect to MQTT broker. LWT (Last Will Testament) is auto-generated from the device name.
+                bool connected = _homeAssistant.Connect();
 
                 if (connected)
                 {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
<!--- Bulleted list. Full sentences. Ending with a dot. -->

- Remove the need for a device ID to be passed in to both the `HomeAssistantClient` and the `HomeAssistantInfoDevice` classes.
  - Now the device has an ID that the `HomeAssistantClient` uses as well.
  - This device ID is sanitized to make sure it uses only valid characters for MQTT topics.
 - Auto-generate the LWT used for the availability topic unless it is overriden by the user.
   - The topic used for the LWT is an implementation detail and most users won't need to override it.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If this **fixes** OR **closes** OR  **resolves** an open issue, please link to the issue there using the template bellow (mind the pattern to link there as all issues are tracked in the Home repository) -->
<!--- **JUST** replace NNNNN with the issue number -->
These are improvements to the API that users will use to register devices in HomeAssistant. A single Device ID is sufficient for topic generation, so the one that was provided to the `HomeAssistantClient` made the API uncertain. (E.g. I found myself asking which device ID is going to be used for the topics?).

The second change was to auto-generate the topic used for the LWT availability topic. Most users won't need to specify the topic used so auto-generating it makes the API surface simpler. For those users that DO have a valid need to specify the topic, the parameter is now optional so they can still do that if they need.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Created test devices and added them to my home assistant instance
- Migrated a device that used the previous `nf.HomeAssistant` nuget package

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
  - This results in a breaking change to the API surface
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [x] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
